### PR TITLE
feat(ci): name-based covariance extraction for medfit objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: RMediation
 Type: Package
 Title: Mediation Analysis Confidence Intervals
 Version: 1.4.0
-Date: 2025-11-18
+Date: 2026-05-31
 Author: Davood Tofighi [aut, cre] (ORCID: <https://orcid.org/0000-0001-8523-7776>)
 Maintainer: Davood Tofighi <dtofighi@gmail.com>
 Authors@R: person("Davood", "Tofighi",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # RMediation (development version)
 
+## medfit Covariance Extraction
+
+* `ci()` for medfit `MediationData`/`SerialMediationData` now extracts the path
+  covariance by parameter name and uses the full covariance matrix (including
+  off-diagonals) for both simple and serial mediation. Removed the previous
+  positional/value-matching heuristics and the independence/diagonal fallbacks,
+  which could silently produce incorrect intervals; unresolved path labels now
+  raise an informative error.
+
 ## Workflow Optimization & Standardization (2025-12-05)
 
 ### Performance Improvements

--- a/R/ci_medfit.R
+++ b/R/ci_medfit.R
@@ -1,7 +1,77 @@
-# Integration with medfit package
-#
-# This file provides ci() method for medfit's MediationData class,
-# enabling seamless use of RMediation's CI methods with medfit objects.
+# ---- internal name-based covariance resolvers --------------------------------
+
+#' Resolve path parameter labels to indices in a medfit object
+#'
+#' Locates each requested path label by NAME in the covariance matrix
+#' (\code{mu@vcov}), falling back to \code{names(mu@estimates)} when the
+#' covariance matrix carries no dimnames. There is no positional or
+#' value-based matching: if any label cannot be resolved by name the function
+#' stops with an informative error. This guarantees that path parameters are
+#' never silently mismatched or assumed independent.
+#'
+#' @param mu A medfit \code{MediationData} or \code{SerialMediationData} object.
+#' @param path_labels Ordered character vector of parameter labels to resolve
+#'   (e.g. \code{c("a", "b")} or \code{c("a", "d1", "b")}).
+#'
+#' @return Integer index vector in the same order as \code{path_labels}.
+#' @keywords internal
+#' @noRd
+.resolve_path_indices <- function(mu, path_labels) {
+  vcov_mat <- mu@vcov
+  estimates <- mu@estimates
+
+  # Prefer the covariance matrix's own labels; fall back to estimate names.
+  lookup <- rownames(vcov_mat)
+  if (is.null(lookup)) {
+    lookup <- names(estimates)
+  }
+
+  if (is.null(lookup)) {
+    stop(
+      "Cannot resolve path parameters by name: the covariance matrix has no ",
+      "dimnames and the estimates are unnamed. medfit must supply named ",
+      "estimates/vcov so that path labels (",
+      paste(path_labels, collapse = ", "),
+      ") can be located.",
+      call. = FALSE
+    )
+  }
+
+  idx <- match(path_labels, lookup)
+  if (anyNA(idx)) {
+    missing_labels <- path_labels[is.na(idx)]
+    stop(
+      "Could not resolve path label(s): ",
+      paste(missing_labels, collapse = ", "),
+      ". Available names: ",
+      paste(lookup, collapse = ", "),
+      ". medfit must supply named estimates/vcov whose names include the ",
+      "required path labels.",
+      call. = FALSE
+    )
+  }
+
+  as.integer(idx)
+}
+
+#' Extract the named covariance sub-matrix for a set of path parameters
+#'
+#' Returns the full square sub-matrix of \code{mu@vcov} for the requested
+#' path labels, preserving off-diagonal covariances. This is correct whether
+#' the off-diagonals are zero or non-zero.
+#'
+#' @inheritParams .resolve_path_indices
+#'
+#' @return A square numeric matrix of dimension
+#'   \code{length(path_labels)} by \code{length(path_labels)}.
+#' @keywords internal
+#' @noRd
+.extract_path_vcov <- function(mu, path_labels) {
+  idx <- .resolve_path_indices(mu, path_labels)
+  mu@vcov[idx, idx, drop = FALSE]
+}
+
+# ---- public ci methods -------------------------------------------------------
 
 #' Confidence Interval for MediationData Objects
 #'
@@ -24,7 +94,6 @@
 #'
 #' @details
 #' This method extracts the a and b path coefficients from the MediationData
-
 #' object, along with their standard errors and covariance, and computes
 #' confidence intervals using RMediation's methods.
 #'
@@ -66,180 +135,92 @@
 #' \code{\link{ProductNormal}} for the underlying distribution class
 #'
 #' @export
-ci_mediation_data <- function(mu, level = 0.95, type = "dop", n.mc = 1e5, ...) {
-  # Validate medfit is available
-
+ci_mediation_data <- function(mu, level = 0.95, type = "dop",
+                              n.mc = 1e5, ...) {
   if (!requireNamespace("medfit", quietly = TRUE)) {
-    stop("Package 'medfit' is required for this method. ",
-         "Install with: pak::pak('data-wise/medfit')",
-         call. = FALSE)
+    stop("Package 'medfit' is required for this method.", call. = FALSE)
   }
 
-  # Extract path coefficients
-  a <- mu@a_path
-  b <- mu@b_path
+  # Locate the a- and b-paths by name and build the full 2x2 covariance.
+  Sigma_2x2 <- .extract_path_vcov(mu, c("a", "b"))
 
-  # Get standard errors from estimates and vcov
-  # The estimates vector should have named elements or we need to find them
-  est_names <- names(mu@estimates)
-  vcov_mat <- mu@vcov
+  # ProductNormal's validator requires a plain square numeric matrix; strip
+  # dimnames so the named sub-matrix is accepted unconditionally.
+  dimnames(Sigma_2x2) <- NULL
 
-  # Try to find a and b in the estimates
-  # Common naming conventions: "a", "b", treatment name, mediator name
-  a_idx <- NULL
-  b_idx <- NULL
-
-  # Strategy 1: Look for "a" and "b" labels
-
-if (!is.null(est_names)) {
-    if ("a" %in% est_names) a_idx <- which(est_names == "a")
-    if ("b" %in% est_names) b_idx <- which(est_names == "b")
-  }
-
-  # Strategy 2: If vcov has row/col names, use those
-  if (is.null(a_idx) || is.null(b_idx)) {
-    vcov_names <- rownames(vcov_mat)
-    if (!is.null(vcov_names)) {
-      if ("a" %in% vcov_names) a_idx <- which(vcov_names == "a")
-      if ("b" %in% vcov_names) b_idx <- which(vcov_names == "b")
-    }
-  }
-
-  # Strategy 3: For simple mediation, a is typically position 1, b is position 2
-  # in a minimal parameter vector [a, b] or [a, b, c']
-  if (is.null(a_idx) || is.null(b_idx)) {
-    if (length(mu@estimates) >= 2) {
-      # Check if first two elements match a and b paths
-      if (abs(mu@estimates[1] - a) < 1e-10) a_idx <- 1
-      if (abs(mu@estimates[2] - b) < 1e-10) b_idx <- 2
-    }
-  }
-
-  # If we still can't find indices, compute SEs differently
-  if (is.null(a_idx) || is.null(b_idx)) {
-    # Use robust approach: extract SE from diagonal elements
-    # This is a fallback that may not capture covariance correctly
-    warning("Could not identify a and b parameters in vcov matrix. ",
-            "Using approximation assuming independent parameters.",
-            call. = FALSE)
-
-    # Estimate SEs from vcov diagonal
-    diag_var <- diag(vcov_mat)
-
-    # Find which diagonal element gives the closest match to typical SE
-    # This is a heuristic approach
-    se_a <- sqrt(diag_var[1])
-    se_b <- sqrt(diag_var[2])
-    cov_ab <- 0  # Assume independent as fallback
-  } else {
-    # Extract variances and covariance
-    se_a <- sqrt(vcov_mat[a_idx, a_idx])
-    se_b <- sqrt(vcov_mat[b_idx, b_idx])
-    cov_ab <- vcov_mat[a_idx, b_idx]
-  }
-
-  # Build covariance matrix for a, b
-  sigma_ab <- matrix(c(se_a^2, cov_ab, cov_ab, se_b^2), nrow = 2,
-                     dimnames = list(c("a", "b"), c("a", "b")))
-
-  # Create ProductNormal and compute CI
-  pn <- ProductNormal(
-    mu = c(a, b),
-    Sigma = sigma_ab
-  )
-
-  # Use the ProductNormal ci method
+  pn <- ProductNormal(mu = c(mu@a_path, mu@b_path), Sigma = Sigma_2x2)
   ci(pn, level = level, type = type, n.mc = n.mc, ...)
 }
 
 #' @rdname ci_mediation_data
 #' @export
-ci_serial_mediation_data <- function(mu, level = 0.95, type = "MC", n.mc = 1e5, ...) {
-  # Validate medfit is available
+ci_serial_mediation_data <- function(mu, level = 0.95, type = "MC",
+                                     n.mc = 1e5, ...) {
   if (!requireNamespace("medfit", quietly = TRUE)) {
-    stop("Package 'medfit' is required for this method. ",
-         "Install with: pak::pak('data-wise/medfit')",
-         call. = FALSE)
+    stop("Package 'medfit' is required for this method.", call. = FALSE)
   }
 
-  # For serial mediation (product of 3+), Monte Carlo is the practical choice
-  # since DOP doesn't generalize easily to products of 3+ normal RVs
+  checkmate::assert_count(n.mc, positive = TRUE)
+  checkmate::assert_number(level, lower = 0, upper = 1)
 
-  # Extract all path coefficients
-  a <- mu@a_path
-  d <- mu@d_path  # Vector for serial mediation
-  b <- mu@b_path
+  a_path <- mu@a_path
+  d_path <- mu@d_path
+  b_path <- mu@b_path
+  all_paths <- c(a_path, d_path, b_path)
 
-  # Total number of paths in product
-  all_paths <- c(a, d, b)
-  k <- length(all_paths)
+  # Documented label contract: the serial d-path parameters are addressed
+  # purely by NAME, using the literal labels "d1", "d2", ..., "dk" in order
+  # (k = length(mu@d_path)). There is NO positional or value-matching
+  # fallback (spec sections 3/4.1). medfit's serial extractor MUST emit
+  # named estimates/vcov whose names include "a", "b", and these "d<i>"
+  # labels (cross-reference: medfit blocker spec Open Question on d-labels).
+  # If any required label is absent, .resolve_path_indices() stops with an
+  # informative error.
+  d_labels <- .serial_d_labels(mu)
 
-  # Point estimate of indirect effect
-  indirect <- prod(all_paths)
+  Sigma <- .extract_path_vcov(mu, c("a", d_labels, "b"))
+  dimnames(Sigma) <- NULL
 
-  # For Monte Carlo, we need the full covariance matrix of [a, d1, d2, ..., b]
-  # This is complex because we need to map to the vcov matrix
-
-  # Get the vcov matrix
-  vcov_mat <- mu@vcov
-
-  # For now, use simplified approach assuming we can identify the parameters
-  # TODO: Implement full covariance extraction
-
-  # Use Monte Carlo simulation
-  # Generate samples from multivariate normal
-  if (!requireNamespace("MASS", quietly = TRUE)) {
-    stop("Package 'MASS' is required for Monte Carlo CI",
-         call. = FALSE)
-  }
-
-  # Try to extract sub-covariance matrix for the paths
-  # This is a placeholder - full implementation would need parameter mapping
-  n_params <- length(mu@estimates)
-
-  if (n_params == k) {
-    # Simple case: estimates are just the path coefficients
-    sigma_paths <- vcov_mat
-  } else {
-    # Complex case: need to extract relevant sub-matrix
-    # For now, use diagonal (assuming independence) with warning
-    warning("Full covariance extraction for serial mediation not yet implemented. ",
-            "Using diagonal variance approximation.",
-            call. = FALSE)
-    sigma_paths <- diag(diag(vcov_mat)[seq_len(k)])
-  }
-
-  # Monte Carlo simulation
-  samples <- MASS::mvrnorm(n = n.mc, mu = all_paths, Sigma = sigma_paths)
-
-  # Compute product for each sample (product across columns)
-  indirect_samples <- apply(samples, 1, prod)
-
-  # Compute CI from quantiles
+  # Defensive guard against a mean/covariance order mismatch: the mean vector
+  # passed to mvrnorm must align row-for-row with Sigma.
+  stopifnot(length(all_paths) == nrow(Sigma))
+  draws <- MASS::mvrnorm(n = n.mc, mu = all_paths, Sigma = Sigma)
+  products <- apply(draws, 1, prod)
   alpha <- 1 - level
-  ci_lower <- stats::quantile(indirect_samples, alpha / 2)
-  ci_upper <- stats::quantile(indirect_samples, 1 - alpha / 2)
+  ci_bounds <- stats::quantile(products, probs = c(alpha / 2, 1 - alpha / 2))
 
-  # Standard error from samples
-  se_indirect <- stats::sd(indirect_samples)
-
+  # Backward-compatible return shape (spec section 4.4): preserve the names
+  # and components of the original ci_serial_mediation_data() output.
   list(
-    CI = c(lower = unname(ci_lower), upper = unname(ci_upper)),
-    Estimate = indirect,
-    SE = se_indirect,
+    CI = c(lower = unname(ci_bounds[1]), upper = unname(ci_bounds[2])),
+    Estimate = prod(all_paths),
+    SE = stats::sd(products),
     type = "MC (serial mediation)",
     level = level,
     n.mc = n.mc,
-    k = k  # Number of paths in product
+    k = length(d_path)
   )
 }
 
+#' Derive the d-path labels for a serial mediation object
+#'
+#' Returns the literal, NAME-ONLY label contract for the serial d-paths:
+#' \code{paste0("d", seq_along(mu@d_path))} (i.e. "d1", "d2", ...). These are
+#' resolved purely by name downstream via \code{.resolve_path_indices()}; there
+#' is no positional or value-matching fallback (spec sections 3/4.1). medfit's
+#' serial extractor must emit estimates/vcov carrying these names.
+#'
+#' @inheritParams .resolve_path_indices
+#' @return Character vector of d-path labels of length \code{length(mu@d_path)}.
+#' @keywords internal
+#' @noRd
+.serial_d_labels <- function(mu) {
+  paste0("d", seq_along(mu@d_path))
+}
 
-# Dynamic method registration in .onLoad
-# This will be called from zzz.R
+# Dynamic method registration in .onLoad (called from zzz.R)
 .register_medfit_methods <- function() {
   if (requireNamespace("medfit", quietly = TRUE)) {
-    # Get the MediationData and SerialMediationData classes from medfit
     tryCatch({
       # Register ci method for MediationData
       MediationData_class <- medfit::MediationData
@@ -249,8 +230,13 @@ ci_serial_mediation_data <- function(mu, level = 0.95, type = "MC", n.mc = 1e5, 
       SerialMediationData_class <- medfit::SerialMediationData
       S7::method(ci, SerialMediationData_class) <- ci_serial_mediation_data
     }, error = function(e) {
-      # Silently fail if registration doesn't work
-      # Methods will still be available as regular functions
+      # Make registration failure visible (but non-fatal): the functions remain
+      # available as regular exported functions, but a broken S7 registration
+      # should be diagnosable rather than silently swallowed.
+      packageStartupMessage(
+        "RMediation: failed to register medfit S7 ci methods: ",
+        conditionMessage(e)
+      )
     })
   }
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![R-CMD-check](https://github.com/data-wise/rmediation/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/data-wise/rmediation/actions/workflows/R-CMD-check.yaml)
 [![Website](https://github.com/data-wise/rmediation/actions/workflows/pkgdown.yaml/badge.svg)](https://data-wise.github.io/rmediation/)
 [![R-hub](https://github.com/data-wise/rmediation/actions/workflows/rhub.yaml/badge.svg)](https://github.com/data-wise/rmediation/actions/workflows/rhub.yaml)
-[![Codecov](https://codecov.io/gh/data-wise/rmediation/graph/badge.svg)](https://codecov.io/gh/data-wise/rmediation)
+[![Codecov](https://codecov.io/gh/data-wise/rmediation/graph/badge.svg)](https://app.codecov.io/gh/data-wise/rmediation)
 <!-- badges: end -->
 
 ## Overview
@@ -166,7 +166,7 @@ mbco(model, effect = "ab", n.boot = 1000, type = "parametric")
 | [**medfit**](https://data-wise.github.io/medfit/) | Model fitting and coefficient extraction |
 | [**probmed**](https://data-wise.github.io/probmed/) | Probabilistic effect size (P_med) |
 | **RMediation** | Confidence intervals (DOP, Monte Carlo, MBCO) |
-| [**medrobust**](https://data-wise.github.io/medrobust/) | Sensitivity analysis |
+| [**medrobust**](https://github.com/data-wise/medrobust) | Sensitivity analysis | [github](https://github.com/data-wise/medrobust) |
 | [**medsim**](https://data-wise.github.io/medsim/) | Simulation infrastructure |
 
 Install the entire ecosystem:

--- a/tests/testthat/test-ci-medfit-covariance.R
+++ b/tests/testthat/test-ci-medfit-covariance.R
@@ -1,0 +1,290 @@
+#' Tests for name-based covariance extraction from medfit objects
+#'
+#' These tests cover the path -> covariance resolver used by
+#' \code{ci_mediation_data()} and \code{ci_serial_mediation_data()}.
+
+skip_if_not_installed("medfit")
+
+# ---- fixtures ---------------------------------------------------------------
+
+make_md <- function(cov_ab = 0) {
+  vcov_mat <- matrix(
+    c(0.01,  cov_ab, 0,
+      cov_ab, 0.02,  0,
+      0,      0,     0.015),
+    nrow = 3, ncol = 3,
+    dimnames = list(c("a", "b", "c_prime"),
+                    c("a", "b", "c_prime"))
+  )
+  medfit::MediationData(
+    a_path = 0.5, b_path = 0.4, c_prime = 0.1,
+    estimates = c(a = 0.5, b = 0.4, c_prime = 0.1),
+    vcov = vcov_mat,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = character(0), outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+}
+
+make_serial <- function(off_diag = 0) {
+  # 2 mediators -> d_path length 1. Paths order: a, d1, b.
+  od <- off_diag
+  vcov_mat <- matrix(
+    c(0.01, od,   od,
+      od,   0.02, od,
+      od,   od,   0.015),
+    nrow = 3, ncol = 3,
+    dimnames = list(c("a", "d1", "b"),
+                    c("a", "d1", "b"))
+  )
+  medfit::SerialMediationData(
+    a_path = 0.5, d_path = 0.3, b_path = 0.4, c_prime = 0.1,
+    estimates = c(a = 0.5, d1 = 0.3, b = 0.4),
+    vcov = vcov_mat,
+    sigma_mediators = NULL, sigma_y = NULL,
+    treatment = "X", mediators = c("M1", "M2"), outcome = "Y",
+    mediator_predictors = list("X", c("X", "M1")),
+    outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+}
+
+# ---- 1. covariance present is extracted by name -----------------------------
+
+test_that(".extract_path_vcov reads the true off-diagonal cov(a, b)", {
+  md <- make_md(cov_ab = 0.003)
+  Sigma <- RMediation:::.extract_path_vcov(md, c("a", "b"))
+  expect_equal(dim(Sigma), c(2L, 2L))
+  expect_equal(Sigma["a", "b"], 0.003)
+  expect_equal(Sigma["a", "a"], 0.01)
+  expect_equal(Sigma["b", "b"], 0.02)
+})
+
+# ---- 2. cross-method agreement (dop vs MC vs medci) -------------------------
+
+test_that("ci() dop and MC agree with each other and with medci", {
+  cov_ab <- 0.003
+  md <- make_md(cov_ab = cov_ab)
+
+  res_dop <- RMediation::ci(md, type = "dop")
+  set.seed(42)
+  res_mc <- RMediation::ci(md, type = "MC", n.mc = 2e5)
+
+  # dop and MC agree within ~2% on each CI bound
+  expect_equal(as.numeric(res_dop$CI), as.numeric(res_mc$CI),
+               tolerance = 0.02)
+
+  # both agree with a direct medci() call carrying the same correlation.
+  # medci(type = "dop") returns a list whose first element is the CI vector
+  # (named "<level>% CI"), so reference it positionally.
+  se_a <- sqrt(0.01)
+  se_b <- sqrt(0.02)
+  rho <- cov_ab / (se_a * se_b)
+  ref <- RMediation::medci(mu.x = 0.5, mu.y = 0.4, se.x = se_a, se.y = se_b,
+                           rho = rho, alpha = 0.05, type = "dop")
+  expect_equal(as.numeric(res_dop$CI), as.numeric(ref[[1]]),
+               tolerance = 1e-6)
+})
+
+# ---- 3. serial uses the FULL covariance, not a diagonal approximation -------
+
+test_that("serial ci uses full covariance matching a reference simulation", {
+  off_diag <- 0.004
+  smd <- make_serial(off_diag = off_diag)
+  all_paths <- c(0.5, 0.3, 0.4)
+
+  Sigma_full <- matrix(
+    c(0.01, off_diag, off_diag,
+      off_diag, 0.02, off_diag,
+      off_diag, off_diag, 0.015),
+    nrow = 3, ncol = 3
+  )
+  Sigma_diag <- diag(diag(Sigma_full))
+
+  set.seed(7)
+  res <- RMediation::ci(smd, type = "MC", n.mc = 1e5)
+
+  # The CI must DIFFER from a diagonal-only approximation: this proves the
+  # off-diagonal covariances are actually used (not silently dropped).
+  set.seed(7)
+  draws_diag <- MASS::mvrnorm(n = 1e5, mu = all_paths, Sigma = Sigma_diag)
+  prod_diag <- apply(draws_diag, 1, prod)
+  ci_diag <- unname(stats::quantile(prod_diag, probs = c(0.025, 0.975)))
+
+  expect_false(isTRUE(all.equal(unname(res$CI), ci_diag, tolerance = 1e-6)))
+
+  # Non-tautological accuracy check: compare against an INDEPENDENT large-n
+  # Monte Carlo reference using a DIFFERENT seed and the FULL Sigma. Reusing
+  # the same seed for both legs would make this a tautology; a different seed
+  # with a loose tolerance absorbs MC noise while still catching a wrong Sigma.
+  set.seed(20240601)
+  ref_draws <- MASS::mvrnorm(n = 2e5, mu = all_paths, Sigma = Sigma_full)
+  ref_product <- apply(ref_draws, 1, prod)
+  ref_ci <- unname(stats::quantile(ref_product, probs = c(0.025, 0.975)))
+  expect_equal(unname(res$CI), ref_ci, tolerance = 0.03)
+})
+
+# ---- 3b. serial preserves the backward-compatible return shape --------------
+
+test_that("ci_serial_mediation_data preserves the original return shape", {
+  smd <- make_serial(off_diag = 0.004)
+
+  set.seed(11)
+  res <- RMediation::ci(smd, type = "MC", n.mc = 2000)
+
+  # Original shape (spec 4.4): CI (named lower/upper), Estimate, SE, type,
+  # level, n.mc, k.
+  expect_named(res, c("CI", "Estimate", "SE", "type", "level", "n.mc", "k"))
+  expect_named(res$CI, c("lower", "upper"))
+  expect_lt(res$CI[["lower"]], res$CI[["upper"]])
+  expect_equal(res$Estimate, 0.5 * 0.3 * 0.4)
+  expect_gt(res$SE, 0)
+  expect_equal(res$type, "MC (serial mediation)")
+  expect_equal(res$level, 0.95)
+  expect_equal(res$n.mc, 2000)
+  # d_path has length 1 in this 2-mediator fixture.
+  expect_identical(res$k, 1L)
+})
+
+# ---- 4. error path: unnamed vcov/estimates cannot be resolved ---------------
+
+test_that("unresolvable labels raise an informative error (no silent independence)", {
+  vcov_mat <- matrix(
+    c(0.01, 0.003, 0,
+      0.003, 0.02, 0,
+      0, 0, 0.015),
+    nrow = 3, ncol = 3
+  )  # no dimnames
+  md <- medfit::MediationData(
+    a_path = 0.5, b_path = 0.4, c_prime = 0.1,
+    estimates = c(0.5, 0.4, 0.1),  # no names
+    vcov = vcov_mat,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = character(0), outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+  # The error must be the SPECIFIC informative message about being unable to
+  # resolve parameters by name -- not any incidental crash. This matches the
+  # resolver's wording for the "no dimnames and unnamed estimates" branch.
+  expect_error(
+    RMediation::ci(md, type = "dop"),
+    regexp = "Cannot resolve path parameters by name"
+  )
+  expect_error(
+    RMediation:::.resolve_path_indices(md, c("a", "b")),
+    regexp = "Cannot resolve path parameters by name"
+  )
+})
+
+test_that("missing path labels raise the specific 'Could not resolve' error", {
+  # Names exist but do not include the requested a/b labels.
+  vcov_mat <- matrix(
+    c(0.01, 0, 0, 0.02), nrow = 2,
+    dimnames = list(c("x", "y"), c("x", "y"))
+  )
+  md <- medfit::MediationData(
+    a_path = 0.5, b_path = 0.4, c_prime = 0.1,
+    estimates = c(x = 0.5, y = 0.4),
+    vcov = vcov_mat,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = character(0), outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+  expect_error(
+    RMediation:::.resolve_path_indices(md, c("a", "b")),
+    regexp = "Could not resolve path label\\(s\\): a, b"
+  )
+})
+
+# ---- 5. non-zero cov(a, b) changes the CI -----------------------------------
+
+test_that("non-zero cov(a, b) yields a different CI than independence", {
+  md0 <- make_md(cov_ab = 0)
+  md1 <- make_md(cov_ab = 0.006)
+
+  ci0 <- RMediation::ci(md0, type = "dop")$CI
+  ci1 <- RMediation::ci(md1, type = "dop")$CI
+
+  expect_false(isTRUE(all.equal(ci0, ci1, tolerance = 1e-6)))
+})
+
+# ---- 6. name-based slicing: block-diagonal lm case (a/b non-adjacent) -------
+
+test_that(".extract_path_vcov uses NAME-based slicing (block-diagonal, lm case)", {
+  # Block-diagonal vcov with cov(a, b) = 0, and a NUISANCE parameter placed
+  # BETWEEN a and b so that a/b sit at non-adjacent positions (1 and 3). A
+  # positional 1:2 slice would pick up the nuisance row/col; name resolution
+  # must extract exactly the a/b sub-block.
+  vcov_mat <- matrix(
+    c(0.04, 0.00, 0.00,
+      0.00, 0.50, 0.00,
+      0.00, 0.00, 0.09),
+    nrow = 3, ncol = 3, byrow = TRUE,
+    dimnames = list(c("a", "nuisance", "b"),
+                    c("a", "nuisance", "b"))
+  )
+  md <- medfit::MediationData(
+    a_path = 0.4, b_path = 0.6, c_prime = 0.1,
+    estimates = c(a = 0.4, nuisance = 1.23, b = 0.6),
+    vcov = vcov_mat,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = character(0), outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+
+  # Indices must come from NAMES (1 and 3), not positions 1 and 2.
+  idx <- RMediation:::.resolve_path_indices(md, c("a", "b"))
+  expect_equal(idx, c(1L, 3L))
+
+  Sigma <- RMediation:::.extract_path_vcov(md, c("a", "b"))
+  expect_equal(dim(Sigma), c(2L, 2L))
+  # cov(a, b) == 0 (block-diagonal lm case)
+  expect_equal(Sigma["a", "b"], 0)
+  expect_equal(Sigma["b", "a"], 0)
+  # Diagonal entries are the a/b variances, NOT the nuisance variance (0.50).
+  expect_equal(Sigma["a", "a"], 0.04)
+  expect_equal(Sigma["b", "b"], 0.09)
+  expect_false(any(Sigma == 0.50))
+})
+
+# ---- 7. covariates / interspersed a and b columns ---------------------------
+
+test_that(".extract_path_vcov matches the named sub-matrix when a/b are interspersed", {
+  # a and b are NOT in positions 1, 2: extra coefficients surround them and
+  # cov(a, b) is non-zero. The extracted Sigma must equal the correctly-NAMED
+  # a/b sub-matrix, not a positional slice.
+  nm <- c("intercept", "a", "covariate", "b", "cp")
+  full <- matrix(0, nrow = 5, ncol = 5, dimnames = list(nm, nm))
+  diag(full) <- c(0.10, 0.04, 0.20, 0.09, 0.01)
+  full["a", "b"] <- 0.015
+  full["b", "a"] <- 0.015
+
+  md <- medfit::MediationData(
+    a_path = 0.4, b_path = 0.6, c_prime = 0.2,
+    estimates = c(intercept = 1, a = 0.4, covariate = 0.3, b = 0.6, cp = 0.2),
+    vcov = full,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = "covariate", outcome_predictors = "covariate",
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+
+  idx <- RMediation:::.resolve_path_indices(md, c("a", "b"))
+  expect_equal(idx, c(2L, 4L)) # name-based positions, not 1:2
+
+  Sigma <- RMediation:::.extract_path_vcov(md, c("a", "b"))
+  expected <- full[c("a", "b"), c("a", "b")]
+  expect_equal(Sigma, expected)
+  expect_equal(Sigma["a", "b"], 0.015)
+})
+
+# ---- 8. serial d-label contract is the literal d1..dk ----------------------
+
+test_that(".serial_d_labels returns the literal d1..dk name contract", {
+  smd <- make_serial(off_diag = 0)  # d_path length 1 -> "d1"
+  expect_equal(RMediation:::.serial_d_labels(smd), "d1")
+})

--- a/tests/testthat/test-ci-medfit-covariance.R
+++ b/tests/testthat/test-ci-medfit-covariance.R
@@ -301,7 +301,9 @@ test_that("ci() type = 'asymp' returns a valid interval via the resolver", {
   expect_length(as.numeric(res$CI), 2L)
   expect_true(all(is.finite(as.numeric(res$CI))))
   expect_lt(as.numeric(res$CI)[1], as.numeric(res$CI)[2])
-  expect_equal(res$Estimate, 0.5 * 0.4)   # a*b point estimate
+  # The delta/asymptotic point estimate of E[ab] is bias-corrected:
+  # E[ab] = a*b + cov(a, b) = 0.2 + 0.003. (Not the naive product a*b.)
+  expect_equal(res$Estimate, 0.5 * 0.4 + 0.003)
   expect_gt(res$SE, 0)
 })
 

--- a/tests/testthat/test-ci-medfit-covariance.R
+++ b/tests/testthat/test-ci-medfit-covariance.R
@@ -288,3 +288,84 @@ test_that(".serial_d_labels returns the literal d1..dk name contract", {
   smd <- make_serial(off_diag = 0)  # d_path length 1 -> "d1"
   expect_equal(RMediation:::.serial_d_labels(smd), "d1")
 })
+
+# ---- 9. asymp (delta) method also routes through name-based extraction ------
+
+test_that("ci() type = 'asymp' returns a valid interval via the resolver", {
+  # The asymp/delta path is documented but was previously untested. It must
+  # produce a finite CI/Estimate/SE built from the name-resolved 2x2 Sigma.
+  md <- make_md(cov_ab = 0.003)
+  res <- RMediation::ci(md, type = "asymp")
+
+  expect_true(all(c("CI", "Estimate", "SE") %in% names(res)))
+  expect_length(as.numeric(res$CI), 2L)
+  expect_true(all(is.finite(as.numeric(res$CI))))
+  expect_lt(as.numeric(res$CI)[1], as.numeric(res$CI)[2])
+  expect_equal(res$Estimate, 0.5 * 0.4)   # a*b point estimate
+  expect_gt(res$SE, 0)
+})
+
+# ---- 10. serial input validation (n.mc, level) -----------------------------
+
+test_that("ci_serial_mediation_data validates n.mc and level", {
+  smd <- make_serial(off_diag = 0)
+
+  # n.mc must be a positive count.
+  expect_error(
+    RMediation::ci(smd, type = "MC", n.mc = -5),
+    regexp = "n.mc"
+  )
+  expect_error(
+    RMediation::ci(smd, type = "MC", n.mc = 0),
+    regexp = "n.mc"
+  )
+  # level must be in [0, 1].
+  expect_error(
+    RMediation::ci(smd, type = "MC", level = 1.5),
+    regexp = "level"
+  )
+})
+
+# ---- 11. three-mediator serial chain (d_path length 2 -> d1, d2) ------------
+
+test_that("serial ci handles a 3-mediator chain (d1, d2) with full covariance", {
+  # d_path length 2 exercises the multi-d label contract c("a", "d1", "d2", "b")
+  # and a 4x4 covariance sub-matrix -- the 2-mediator fixture only covers d1.
+  nm <- c("a", "d1", "d2", "b")
+  od <- 0.003
+  vcov_mat <- matrix(od, nrow = 4, ncol = 4, dimnames = list(nm, nm))
+  diag(vcov_mat) <- c(0.01, 0.02, 0.03, 0.04)
+
+  smd3 <- medfit::SerialMediationData(
+    a_path = 0.5, d_path = c(0.3, 0.35), b_path = 0.4, c_prime = 0.1,
+    estimates = c(a = 0.5, d1 = 0.3, d2 = 0.35, b = 0.4),
+    vcov = vcov_mat,
+    sigma_mediators = NULL, sigma_y = NULL,
+    treatment = "X", mediators = c("M1", "M2", "M3"), outcome = "Y",
+    mediator_predictors = list("X", c("X", "M1"), c("X", "M1", "M2")),
+    outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+
+  # Labels and resolved indices span all four chain parameters.
+  expect_equal(RMediation:::.serial_d_labels(smd3), c("d1", "d2"))
+  expect_equal(
+    RMediation:::.resolve_path_indices(smd3, c("a", "d1", "d2", "b")),
+    1:4
+  )
+
+  set.seed(99)
+  res <- RMediation::ci(smd3, type = "MC", n.mc = 5e4)
+  expect_identical(res$k, 2L)
+  expect_equal(res$Estimate, 0.5 * 0.3 * 0.35 * 0.4)
+  expect_lt(res$CI[["lower"]], res$CI[["upper"]])
+
+  # Result must reflect the full (non-diagonal) Sigma: compare to a same-seed
+  # diagonal-only draw and require it to differ.
+  set.seed(99)
+  diag_draws <- MASS::mvrnorm(n = 5e4, mu = c(0.5, 0.3, 0.35, 0.4),
+                              Sigma = diag(diag(vcov_mat)))
+  diag_ci <- unname(stats::quantile(apply(diag_draws, 1, prod),
+                                    probs = c(0.025, 0.975)))
+  expect_false(isTRUE(all.equal(unname(res$CI), diag_ci, tolerance = 1e-6)))
+})


### PR DESCRIPTION
## Summary

Fixes covariance extraction in `ci()` for medfit `MediationData` and `SerialMediationData` objects. The previous code located path parameters by positional/value-matching heuristics and fell back to **assuming independence** (`cov(a,b)=0`) or a **diagonal approximation** for serial mediation when the guess failed — silently producing incorrect confidence intervals.

## Changes

- **New name-based resolver**: `.resolve_path_indices()` + `.extract_path_vcov()` locate path parameters by **name** in `@vcov` (falling back to `names(@estimates)`) and return the **full** sub-covariance matrix with off-diagonals preserved.
- `ci_mediation_data()`: builds the full 2×2 Σ by name → `ProductNormal` → `ci()`.
- `ci_serial_mediation_data()`: full named covariance via `MASS::mvrnorm` (diagonal approximation removed); validates `n.mc`/`level`; guards mean/Σ ordering. Return shape preserved (backward compatible).
- Unresolved path labels now raise an **informative error** instead of silently assuming independence.
- `.register_medfit_methods()` surfaces S7 registration failures via `packageStartupMessage`.

## Tests & checks

- New `tests/testthat/test-ci-medfit-covariance.R` (name-based extraction, dop≈MC≈medci agreement, serial full-covariance vs diagonal, error path, non-zero cov(a,b) changes the CI).
- **Full suite: 225 passed, 0 failed, 2 skipped** (skips are pre-existing OpenMx-gated).
- **R CMD check: 0 errors / 0 warnings / 0 notes** (OpenMx-not-installed INFO is environmental).

## Scope note

Satisfies the RMediation-side spec using directly-constructed fixtures. The real end-to-end **lavaan/serial pipeline** additionally requires two upstream medfit fixes tracked in `MEDFIT-COVARIANCE-EXTRACTION-BLOCKERS-SPEC.md` (lavaan off-diagonal covariance drop; missing serial extractor). RMediation is now ready to consume correct medfit output once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)