### PR TITLE
Release: RMediation v1.5.0 (medfit on CRAN — drop Remotes)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,6 +10,8 @@
 ^\.claude$
 ^CLAUDE\.md$
 ^STATUS\.md$
+^\.STATUS$
+^\.STATUS\.backup$
 ^GEMINI\.md$
 ^QWEN\.md$
 ^\.git$

--- a/.STATUS
+++ b/.STATUS
@@ -33,23 +33,22 @@ Carlo, MBCO. S7 is the computational core; legacy functions are thin wrappers.
   * R CMD check (--no-manual, _R_CHECK_FORCE_SUGGESTS_=false) verified 0 errors /
     0 warnings / 0 NOTES. (--as-cran would still show the expected Remotes/medfit NOTE.)
 
-## Next (upstream medfit work, in order)
-- medfit Blocker A: DONE — merged to dev (PR #19). Will reach main on next dev->main release.
-- medfit Blocker B (serial mediation extractor): IN PROGRESS on branch feature/serial-extractor
-  (commit 082f1b9, not yet on dev). Verified via diff peek 2026-05-31:
-  * lavaan serial extractor DONE — .extract_serial_mediation_lavaan(), dispatched from
-    extract_mediation_lavaan() when `mediator` is a length->=2 ordered vector. Named
-    @vcov (a, d1.., b, c_prime) with off-diagonals tested vs lavaan::vcov for 2- and
-    3-mediator chains. Positional d1,d2 labels confirmed. Satisfies 3 of 4 acceptance items.
-  * OPEN GAP: lm/sequential-regression serial path NOT implemented — decision #2 scoped
-    v1 as lavaan + lm, so only half met. Resolve by implementing lm serial OR re-scoping
-    #2 to lavaan-only-for-v1. This is the live front in the medfit session.
-  No conflict risk: PR #19 was a true merge (not squash), so the serial branch's base
-  commits are already on dev with identical SHAs — merging serial -> dev only adds new commits.
-  Design decisions RESOLVED 2026-05-31: positional d1,d2,... labels; lavaan + lm scope;
-  auto-detect serial in extract_mediation(). Spec checklist updated + pushed
-  (mediation-planning bb6a1ae, branch docs/planning-update-2026-05-31):
-  specs/MEDFIT-COVARIANCE-EXTRACTION-BLOCKERS-SPEC.md
+## Next (medfit blockers DONE — now rmediation-side verification + CRAN wait)
+- medfit Blockers A & B: DONE — RELEASED in medfit v0.2.0 (tagged; on origin/main via PR #27;
+  verified vs remote 2026-06-01). Serial extractor ships BOTH lavaan (ordered mediator vector)
+  AND lm/glm (new mediator_models arg); @vcov named a,d1..,b,c_prime per the agreed contract
+  (lavaan keeps off-diagonals; lm block-diagonal with cov(b,c') preserved). The earlier "lm gap"
+  is CLOSED.
+- medfit CRAN: SUBMITTED — initial submission of v0.2.0 (R CMD check 0/0/1 new-submission note;
+  win-builder + GHA matrix done). NOT yet accepted — treat as CRAN-PENDING.
+- rmediation serial pipeline: code already written (R/ci_medfit.R: ci_serial_mediation_data(),
+  .serial_d_labels = paste0("d", seq_along(@d_path)) -> the d1,d2 contract medfit now emits).
+  UNBLOCKED. REMAINING WORK: installed medfit is still 0.1.0 — (1) install medfit 0.2.0 locally,
+  (2) verify the serial pipeline end-to-end (fit serial model -> medfit::extract_mediation ->
+  ci()) against the REAL extractor, (3) add an integration test exercising real extraction
+  (existing serial tests likely use hand-built SerialMediationData). Do this on a feature branch.
+- RMediation v1.5.0: flip medfit Suggests -> Imports once medfit is ACCEPTED on CRAN (CRAN forbids
+  Remotes:), then release. Gated on CRAN ACCEPTANCE, not submission.
 - Then RMediation's serial lavaan pipeline is fully wireable end-to-end (lavaan path ready now;
   lm path waits on the gap above).
 - RMediation v1.5.0: move medfit Suggests -> Imports once medfit reaches CRAN

--- a/.STATUS
+++ b/.STATUS
@@ -25,6 +25,13 @@ Carlo, MBCO. S7 is the computational core; legacy functions are thin wrappers.
   NOTE: a mid-session check briefly found it unmerged and this file was "corrected" to
   say so — that was a timing artifact (PR #19 was merged in the medfit session shortly
   after). Current verified truth: A is on dev, NOT yet on main (dev->main release pending).
+- rmediation own-repo housekeeping this session (all on dev, pushed, CI green):
+  * 2bdd0b1 renamed develop -> dev (branch local+origin, CI triggers in both workflows,
+    README @dev install refs); CI confirmed firing + passing on dev.
+  * cd5c50e began tracking .STATUS (was untracked); 4ed2de7 added ^\.STATUS$ +
+    ^\.STATUS\.backup$ to .Rbuildignore so it stays in git but out of the tarball.
+  * R CMD check (--no-manual, _R_CHECK_FORCE_SUGGESTS_=false) verified 0 errors /
+    0 warnings / 0 NOTES. (--as-cran would still show the expected Remotes/medfit NOTE.)
 
 ## Next (upstream medfit work, in order)
 - medfit Blocker A: DONE — merged to dev (PR #19). Will reach main on next dev->main release.
@@ -50,7 +57,9 @@ Carlo, MBCO. S7 is the computational core; legacy functions are thin wrappers.
 - DONE 2026-05-31: renamed develop -> dev (local + origin; CI triggers, README
   install refs updated). Default branch remains main.
 
-## Session end: 2026-05-31
+## Session end: 2026-05-31 (wrap via /workflow:done)
+- This session (rmediation): dev rename, .STATUS tracking + build-exclude, R CMD check
+  clean 0/0/0. All committed and pushed; repo clean and in sync on dev. No own-repo TODOs.
 - Live front (medfit session, NOT rmediation): finish Blocker B's lm serial path
   (or re-scope decision #2 to lavaan-only), then land feature/serial-extractor -> dev.
 - rmediation itself is fully parked: nothing actionable here until B lands on dev

--- a/.STATUS
+++ b/.STATUS
@@ -65,9 +65,11 @@ Carlo, MBCO. S7 is the computational core; legacy functions are thin wrappers.
   ACCEPTANCE, not submission. Pre-staged diff: medfit/planning/CASCADE-cran-flip-2026-06-03.md.
   (Deferred to v1.5.0: user-facing serial+medfit vignette/README examples — medfit-gated, need
   requireNamespace guards.)
-- CRAN-acceptance monitors: TWO daily routines now watch this — trig_01YHbGpx42Hj1d5vyfLWf2oq
-  (8am MDT, rmediation-side) and trig_018qiNZMTUP5Az2UGXyv6vRf "medfit-cran-watch" (9am MDT,
-  page + Gmail, created 2026-06-03). Redundant — delete one once medfit lands. CRAN also emails.
+- CRAN-acceptance monitor: ONE active routine — trig_018qiNZMTUP5Az2UGXyv6vRf "medfit-cran-watch"
+  (9am MDT, checks CRAN page + Gmail, includes post-acceptance checklist). The older
+  trig_01YHbGpx42Hj1d5vyfLWf2oq (8am, rmediation-side) was DISABLED 2026-06-03 as a duplicate (its
+  prompt also gave the now-superseded "Suggests->Imports" advice); hard-delete via the routines UI
+  when convenient. CRAN also emails the maintainer.
 - Then RMediation's serial lavaan pipeline is fully wireable end-to-end (lavaan path ready now;
   lm path waits on the gap above).
 - RMediation v1.5.0: on CRAN acceptance, drop `Remotes:` + pin `medfit (>= 0.2.0)` in **Suggests**

--- a/.STATUS
+++ b/.STATUS
@@ -2,7 +2,19 @@
 
 ## Status: Active
 ## Progress: 100
-## Focus: v1.5.0 prep — serial pipeline merged + verified; awaiting medfit CRAN acceptance
+## Focus: v1.5.0 code-complete + re-verified vs medfit 0.2.0 (2026-06-03); awaiting medfit CRAN acceptance
+
+## Verified 2026-06-03 (re-ran vs the medfit 0.2.0 RELEASE TARBALL)
+- Installed medfit 0.2.0 from `medfit_0.2.0.tar.gz` (R CMD INSTALL); both S7 classes exported.
+- medfit integration tests (test-serial-medfit-integration.R + test-ci-medfit-covariance.R):
+  **68 pass / 0 fail / 0 skip**.
+- Full rmediation suite (12 files): **261 pass / 0 fail / 2 skip / 18 warn**. Skips = OpenMx/MxModel
+  mbco tests (OpenMx not installed). Warnings = pre-existing legacy-compat/deprecation in test-ci.R
+  + test-legacy-compat.R, none medfit-related.
+- Live demo: lavaan serial indirect = 0.2086 (95% CI [0.170, 0.251]); lm/glm = 0.2429
+  (95% CI [0.201, 0.289]); both bracket true a*d1*b = 0.21. Contract `a,d1,b,c_prime` confirmed.
+- Conclusion: v1.5.0 is code-complete & verified from source (no CRAN needed for correctness);
+  only the release flip waits on medfit CRAN acceptance.
 
 ## Overview
 R package for confidence intervals of nonlinear functions of model parameters
@@ -47,15 +59,19 @@ Carlo, MBCO. S7 is the computational core; legacy functions are thin wrappers.
   medfit < 0.2.0). CI green on all platforms (macOS/Windows/Ubuntu + coverage). Full suite
   261 pass / 0 fail; R CMD check --as-cran 0/0/1 (only the expected Remotes/medfit NOTE).
   CLAUDE.md medfit section refreshed to "implemented" (f616879).
-- RMediation v1.5.0: flip medfit Suggests -> Imports once medfit is ACCEPTED on CRAN (CRAN forbids
-  Remotes:), then release. Gated on CRAN ACCEPTANCE, not submission. (Deferred to v1.5.0: user-facing
-  serial+medfit vignette/README examples — medfit-gated, need requireNamespace guards.)
-- CRAN-acceptance monitor: daily routine trig_01YHbGpx42Hj1d5vyfLWf2oq (8am MDT) checks if medfit
-  is on CRAN; delete it once medfit lands. CRAN also emails the maintainer.
+- RMediation v1.5.0: on medfit CRAN ACCEPTANCE, KEEP medfit in **Suggests** (do NOT promote to
+  Imports — usage in R/ci_medfit.R is guarded by requireNamespace, the Suggests contract; decided
+  2026-06-03), drop the `Remotes:` line, pin `medfit (>= 0.2.0)`, then release. Gated on CRAN
+  ACCEPTANCE, not submission. Pre-staged diff: medfit/planning/CASCADE-cran-flip-2026-06-03.md.
+  (Deferred to v1.5.0: user-facing serial+medfit vignette/README examples — medfit-gated, need
+  requireNamespace guards.)
+- CRAN-acceptance monitors: TWO daily routines now watch this — trig_01YHbGpx42Hj1d5vyfLWf2oq
+  (8am MDT, rmediation-side) and trig_018qiNZMTUP5Az2UGXyv6vRf "medfit-cran-watch" (9am MDT,
+  page + Gmail, created 2026-06-03). Redundant — delete one once medfit lands. CRAN also emails.
 - Then RMediation's serial lavaan pipeline is fully wireable end-to-end (lavaan path ready now;
   lm path waits on the gap above).
-- RMediation v1.5.0: move medfit Suggests -> Imports once medfit reaches CRAN
-  (CRAN forbids Remotes:); then release
+- RMediation v1.5.0: on CRAN acceptance, drop `Remotes:` + pin `medfit (>= 0.2.0)` in **Suggests**
+  (keep Suggests, per 2026-06-03 decision above); then release
 - DONE 2026-05-31: renamed develop -> dev (local + origin; CI triggers, README
   install refs updated). Default branch remains main.
 

--- a/.STATUS
+++ b/.STATUS
@@ -2,7 +2,7 @@
 
 ## Status: Active
 ## Progress: 100
-## Focus: medfit integration (v1.5.0 prep) — covariance extraction merged
+## Focus: v1.5.0 prep — serial pipeline merged + verified; awaiting medfit CRAN acceptance
 
 ## Overview
 R package for confidence intervals of nonlinear functions of model parameters
@@ -41,14 +41,17 @@ Carlo, MBCO. S7 is the computational core; legacy functions are thin wrappers.
   is CLOSED.
 - medfit CRAN: SUBMITTED — initial submission of v0.2.0 (R CMD check 0/0/1 new-submission note;
   win-builder + GHA matrix done). NOT yet accepted — treat as CRAN-PENDING.
-- rmediation serial pipeline: code already written (R/ci_medfit.R: ci_serial_mediation_data(),
-  .serial_d_labels = paste0("d", seq_along(@d_path)) -> the d1,d2 contract medfit now emits).
-  UNBLOCKED. REMAINING WORK: installed medfit is still 0.1.0 — (1) install medfit 0.2.0 locally,
-  (2) verify the serial pipeline end-to-end (fit serial model -> medfit::extract_mediation ->
-  ci()) against the REAL extractor, (3) add an integration test exercising real extraction
-  (existing serial tests likely use hand-built SerialMediationData). Do this on a feature branch.
+- rmediation serial pipeline: DONE & MERGED to dev (PR #5, 2026-06-02). Verified end-to-end against
+  the REAL medfit 0.2.0 extractor for BOTH lavaan (ordered mediator vector) and lm/glm
+  (mediator_models) chains; integration test test-serial-medfit-integration.R added (skips if
+  medfit < 0.2.0). CI green on all platforms (macOS/Windows/Ubuntu + coverage). Full suite
+  261 pass / 0 fail; R CMD check --as-cran 0/0/1 (only the expected Remotes/medfit NOTE).
+  CLAUDE.md medfit section refreshed to "implemented" (f616879).
 - RMediation v1.5.0: flip medfit Suggests -> Imports once medfit is ACCEPTED on CRAN (CRAN forbids
-  Remotes:), then release. Gated on CRAN ACCEPTANCE, not submission.
+  Remotes:), then release. Gated on CRAN ACCEPTANCE, not submission. (Deferred to v1.5.0: user-facing
+  serial+medfit vignette/README examples — medfit-gated, need requireNamespace guards.)
+- CRAN-acceptance monitor: daily routine trig_01YHbGpx42Hj1d5vyfLWf2oq (8am MDT) checks if medfit
+  is on CRAN; delete it once medfit lands. CRAN also emails the maintainer.
 - Then RMediation's serial lavaan pipeline is fully wireable end-to-end (lavaan path ready now;
   lm path waits on the gap above).
 - RMediation v1.5.0: move medfit Suggests -> Imports once medfit reaches CRAN
@@ -56,12 +59,16 @@ Carlo, MBCO. S7 is the computational core; legacy functions are thin wrappers.
 - DONE 2026-05-31: renamed develop -> dev (local + origin; CI triggers, README
   install refs updated). Default branch remains main.
 
-## Session end: 2026-05-31 (wrap via /workflow:done)
-- This session (rmediation): dev rename, .STATUS tracking + build-exclude, R CMD check
-  clean 0/0/0. All committed and pushed; repo clean and in sync on dev. No own-repo TODOs.
-- Live front (medfit session, NOT rmediation): finish Blocker B's lm serial path
-  (or re-scope decision #2 to lavaan-only), then land feature/serial-extractor -> dev.
-- rmediation itself is fully parked: nothing actionable here until B lands on dev
-  (then wire the serial lavaan pipeline) and medfit reaches CRAN (then v1.5.0
-  Suggests->Imports). Re-verify medfit git log before trusting any A/B status above —
-  state churned mid-session once already.
+## Session end: 2026-06-02 (wrap via /workflow:done)
+- This session: medfit v0.2.0 shipped Blockers A+B (lavaan + lm serial extractor) and is
+  CRAN-SUBMITTED. rmediation serial pipeline verified end-to-end + integration-tested + MERGED
+  to dev (PR #5, CI green all platforms). CLAUDE.md medfit section refreshed to "implemented".
+  CRAN-acceptance monitor routine set up. flow-cli v7.7.1 (terminal-handoff fix) released in a
+  separate session.
+- rmediation is RELEASE-READY for v1.5.0 except the single CRAN-gated step.
+- NEXT (when medfit is ACCEPTED on CRAN): on a branch, flip medfit Suggests->Imports, delete
+  `Remotes: data-wise/medfit` from DESCRIPTION, bump version + Date, finalize NEWS, then release.
+  --as-cran already confirms no other blockers (the lone NOTE clears when medfit is on CRAN).
+- Until then: nothing actionable here. Monitor watches medfit CRAN status daily.
+- Caution: re-verify medfit git log / `available.packages()` before trusting any medfit status
+  above — state has churned across sessions repeatedly (tags, CRAN, this session).

--- a/.STATUS
+++ b/.STATUS
@@ -1,0 +1,59 @@
+# rmediation
+
+## Status: Active
+## Progress: 100
+## Focus: medfit integration (v1.5.0 prep) — covariance extraction merged
+
+## Overview
+R package for confidence intervals of nonlinear functions of model parameters
+(indirect effects) in mediation analysis: Distribution of Product (DOP), Monte
+Carlo, MBCO. S7 is the computational core; legacy functions are thin wrappers.
+
+## CRAN
+- Published version: 1.4.0
+- Development version: 1.4.0 (dev)
+
+## Recent (2026-05-31)
+- Merged PR #4 (develop): name-based path -> covariance extraction for medfit
+  MediationData/SerialMediationData objects in ci(); removed positional/value-
+  matching and independence/diagonal fallbacks; full off-diagonal covariance now
+  used for simple and serial mediation. 240 tests pass; R CMD check clean except
+  the inherent Remotes/medfit-not-on-CRAN NOTE.
+- Upstream medfit Blocker A: MERGED to medfit dev via PR #19 (re-verified 2026-05-31,
+  22:3x — commit 3c2ebec on dev; feature branch cleaned up). lavaan extractor now
+  preserves off-diagonal path covariances; print.mediation_effect S3 dispatch fixed.
+  NOTE: a mid-session check briefly found it unmerged and this file was "corrected" to
+  say so — that was a timing artifact (PR #19 was merged in the medfit session shortly
+  after). Current verified truth: A is on dev, NOT yet on main (dev->main release pending).
+
+## Next (upstream medfit work, in order)
+- medfit Blocker A: DONE — merged to dev (PR #19). Will reach main on next dev->main release.
+- medfit Blocker B (serial mediation extractor): IN PROGRESS on branch feature/serial-extractor
+  (commit 082f1b9, not yet on dev). Verified via diff peek 2026-05-31:
+  * lavaan serial extractor DONE — .extract_serial_mediation_lavaan(), dispatched from
+    extract_mediation_lavaan() when `mediator` is a length->=2 ordered vector. Named
+    @vcov (a, d1.., b, c_prime) with off-diagonals tested vs lavaan::vcov for 2- and
+    3-mediator chains. Positional d1,d2 labels confirmed. Satisfies 3 of 4 acceptance items.
+  * OPEN GAP: lm/sequential-regression serial path NOT implemented — decision #2 scoped
+    v1 as lavaan + lm, so only half met. Resolve by implementing lm serial OR re-scoping
+    #2 to lavaan-only-for-v1. This is the live front in the medfit session.
+  No conflict risk: PR #19 was a true merge (not squash), so the serial branch's base
+  commits are already on dev with identical SHAs — merging serial -> dev only adds new commits.
+  Design decisions RESOLVED 2026-05-31: positional d1,d2,... labels; lavaan + lm scope;
+  auto-detect serial in extract_mediation(). Spec checklist updated + pushed
+  (mediation-planning bb6a1ae, branch docs/planning-update-2026-05-31):
+  specs/MEDFIT-COVARIANCE-EXTRACTION-BLOCKERS-SPEC.md
+- Then RMediation's serial lavaan pipeline is fully wireable end-to-end (lavaan path ready now;
+  lm path waits on the gap above).
+- RMediation v1.5.0: move medfit Suggests -> Imports once medfit reaches CRAN
+  (CRAN forbids Remotes:); then release
+- DONE 2026-05-31: renamed develop -> dev (local + origin; CI triggers, README
+  install refs updated). Default branch remains main.
+
+## Session end: 2026-05-31
+- Live front (medfit session, NOT rmediation): finish Blocker B's lm serial path
+  (or re-scope decision #2 to lavaan-only), then land feature/serial-extractor -> dev.
+- rmediation itself is fully parked: nothing actionable here until B lands on dev
+  (then wire the serial lavaan pipeline) and medfit reaches CRAN (then v1.5.0
+  Suggests->Imports). Re-verify medfit git log before trusting any A/B status above —
+  state churned mid-session once already.

--- a/.STATUS
+++ b/.STATUS
@@ -4,6 +4,13 @@
 ## Progress: 100
 ## Focus: v1.5.0 code-complete + re-verified vs medfit 0.2.0 (2026-06-03); awaiting medfit CRAN acceptance
 
+## Active worktree
+- `~/.git-worktrees/rmediation/feature-v150-medfit-examples` (branch
+  `feature/v150-medfit-examples`, off `dev`, 2026-06-03): drafting the deferred
+  v1.5.0 user-facing examples. DONE so far (commit 59d69f4): new vignette
+  `vignettes/serial-mediation-with-medfit.Rmd` (medfit-guarded, knits clean) +
+  README "Serial Mediation via medfit" subsection. Not yet merged to dev.
+
 ## Verified 2026-06-03 (re-ran vs the medfit 0.2.0 RELEASE TARBALL)
 - Installed medfit 0.2.0 from `medfit_0.2.0.tar.gz` (R CMD INSTALL); both S7 classes exported.
 - medfit integration tests (test-serial-medfit-integration.R + test-ci-medfit-covariance.R):

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master, develop]
+    branches: [main, master, dev]
 
 name: R-CMD-check
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master, develop]
+    branches: [main, master, dev]
 
 name: test-coverage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,11 +120,18 @@ RMediation is an **application package** in the mediationverse ecosystem.
 | medrobust | Sensitivity analysis | Application | https://data-wise.github.io/medrobust/ |
 | medsim | Simulation infrastructure | Support | https://data-wise.github.io/medsim/ |
 
-### Integration with medfit (v1.5.0, Q1 2026)
+### Integration with medfit (v1.5.0)
 
-- Model extraction will use medfit infrastructure
-- Bootstrap utilities may be shared
-- S7 classes may inherit from medfit base classes
+medfit integration is **implemented** as of 2026-06: `ci()` consumes medfit
+`MediationData`/`SerialMediationData` objects, extracting the path covariance by
+parameter name (the `a, d1, ..., b, c_prime` contract). The serial-mediation
+pipeline (`ci_serial_mediation_data()`) is verified end-to-end against medfit's
+released serial extractor (medfit >= 0.2.0), for both lavaan and lm/glm chains.
+
+**Remaining for v1.5.0 release:** medfit is submitted to CRAN and awaiting
+acceptance. Once accepted, move medfit from `Suggests` to `Imports` and remove
+`Remotes: data-wise/medfit` from DESCRIPTION (CRAN forbids `Remotes:`), then
+release. The flip is gated on CRAN acceptance, not submission.
 
 ---
 
@@ -138,4 +145,4 @@ RMediation is an **application package** in the mediationverse ecosystem.
 
 ---
 
-**Last Updated**: 2025-12-04
+**Last Updated**: 2026-06-02

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: RMediation
 Type: Package
 Title: Mediation Analysis Confidence Intervals
 Version: 1.4.0
-Date: 2025-11-18
+Date: 2026-05-31
 Author: Davood Tofighi [aut, cre] (ORCID: <https://orcid.org/0000-0001-8523-7776>)
 Maintainer: Davood Tofighi <dtofighi@gmail.com>
 Authors@R: person("Davood", "Tofighi",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RMediation
 Type: Package
 Title: Mediation Analysis Confidence Intervals
-Version: 1.4.0
-Date: 2026-05-31
+Version: 1.5.0
+Date: 2026-06-18
 Author: Davood Tofighi [aut, cre] (ORCID: <https://orcid.org/0000-0001-8523-7776>)
 Maintainer: Davood Tofighi <dtofighi@gmail.com>
 Authors@R: person("Davood", "Tofighi",
@@ -40,13 +40,11 @@ Imports:
     S7
 Suggests:
     knitr,
-    medfit,
+    medfit (>= 0.2.0),
     OpenMx (>= 2.13),
     rmarkdown,
     testthat (>= 3.0.0)
 VignetteBuilder: knitr
-Remotes:
-    data-wise/medfit
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE, roclets = c("rd", "collate", "namespace"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,32 @@
 # RMediation (development version)
 
+## Workflow Optimization & Standardization (2025-12-05)
+
+### Performance Improvements
+* **Optimized R-CMD-check workflow**: Reduced from 5 to 3 platforms (macOS, Windows, Ubuntu release)
+* **Removed failing platforms**: Dropped `ubuntu-latest (devel)` and `ubuntu-latest (oldrel-1)` configurations
+* **Runtime improvement**: Check workflows now complete in ~2 minutes (down from 6+ minutes, **67% faster**)
+* **Build optimization**: Added `--ignore-vignettes` flag to skip vignette validation during CI checks
+
+### Bug Fixes
+* **Fixed pkgdown build errors**:
+  - Removed non-existent `reexports` topic from `_pkgdown.yml` reference index
+  - Added missing `tidy` topic to `_pkgdown.yml` reference index
+  - pkgdown workflow now passes successfully
+
+### Standardization
+* **Badge order**: Added R-hub badge to README, standardized order to match mediationverse ecosystem:
+  CRAN, Lifecycle, R-CMD-check, Website, R-hub, Codecov
+* **.Rbuildignore**: Added `^STATUS\.md$` to match ecosystem standards
+* **Website configuration**: Already compliant with mediationverse standards:
+  - Academic blue color scheme (#0054AD)
+  - Consistent fonts (Inter, Montserrat, Fira Code)
+  - Ecosystem and Status dropdown menus
+
+### Documentation
+* Updated README badge order for consistency across ecosystem
+* All workflows now passing on main branch
+
 ## Dependency Reduction
 
 * **Removed dependencies**: `e1071`, `modelr`, and `generics` packages are no longer required.

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@
   positional/value-matching heuristics and the independence/diagonal fallbacks,
   which could silently produce incorrect intervals; unresolved path labels now
   raise an informative error.
+* The serial-mediation pipeline is now verified end-to-end against medfit's
+  released serial extractor (medfit >= 0.2.0): `medfit::extract_mediation()`
+  produces a `SerialMediationData` for both lavaan (ordered `mediator` vector)
+  and lm/glm (`mediator_models`) chains, and `ci()` consumes it via the
+  documented `d1, d2, ...` path-name contract. Added integration tests that fit a
+  real model, extract, and run `ci()` end-to-end (skipped when medfit < 0.2.0).
 
 ## Workflow Optimization & Standardization (2025-12-05)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # RMediation (development version)
 
+## medfit Covariance Extraction
+
+* `ci()` for medfit `MediationData`/`SerialMediationData` now extracts the path
+  covariance by parameter name and uses the full covariance matrix (including
+  off-diagonals) for both simple and serial mediation. Removed the previous
+  positional/value-matching heuristics and the independence/diagonal fallbacks,
+  which could silently produce incorrect intervals; unresolved path labels now
+  raise an informative error.
+
 ## Workflow Optimization & Standardization (2025-12-05)
 
 ### Performance Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# RMediation (development version)
+# RMediation 1.5.0 (2026-06-18)
+
+## Dependencies
+
+* **medfit is now available on CRAN** (v0.2.0/0.2.1). Removed `Remotes:
+  data-wise/medfit`; medfit now resolves from CRAN. Pinned `Suggests: medfit
+  (>= 0.2.0)`.
 
 ## medfit Covariance Extraction
 

--- a/R/ci_medfit.R
+++ b/R/ci_medfit.R
@@ -1,7 +1,77 @@
-# Integration with medfit package
-#
-# This file provides ci() method for medfit's MediationData class,
-# enabling seamless use of RMediation's CI methods with medfit objects.
+# ---- internal name-based covariance resolvers --------------------------------
+
+#' Resolve path parameter labels to indices in a medfit object
+#'
+#' Locates each requested path label by NAME in the covariance matrix
+#' (\code{mu@vcov}), falling back to \code{names(mu@estimates)} when the
+#' covariance matrix carries no dimnames. There is no positional or
+#' value-based matching: if any label cannot be resolved by name the function
+#' stops with an informative error. This guarantees that path parameters are
+#' never silently mismatched or assumed independent.
+#'
+#' @param mu A medfit \code{MediationData} or \code{SerialMediationData} object.
+#' @param path_labels Ordered character vector of parameter labels to resolve
+#'   (e.g. \code{c("a", "b")} or \code{c("a", "d1", "b")}).
+#'
+#' @return Integer index vector in the same order as \code{path_labels}.
+#' @keywords internal
+#' @noRd
+.resolve_path_indices <- function(mu, path_labels) {
+  vcov_mat <- mu@vcov
+  estimates <- mu@estimates
+
+  # Prefer the covariance matrix's own labels; fall back to estimate names.
+  lookup <- rownames(vcov_mat)
+  if (is.null(lookup)) {
+    lookup <- names(estimates)
+  }
+
+  if (is.null(lookup)) {
+    stop(
+      "Cannot resolve path parameters by name: the covariance matrix has no ",
+      "dimnames and the estimates are unnamed. medfit must supply named ",
+      "estimates/vcov so that path labels (",
+      paste(path_labels, collapse = ", "),
+      ") can be located.",
+      call. = FALSE
+    )
+  }
+
+  idx <- match(path_labels, lookup)
+  if (anyNA(idx)) {
+    missing_labels <- path_labels[is.na(idx)]
+    stop(
+      "Could not resolve path label(s): ",
+      paste(missing_labels, collapse = ", "),
+      ". Available names: ",
+      paste(lookup, collapse = ", "),
+      ". medfit must supply named estimates/vcov whose names include the ",
+      "required path labels.",
+      call. = FALSE
+    )
+  }
+
+  as.integer(idx)
+}
+
+#' Extract the named covariance sub-matrix for a set of path parameters
+#'
+#' Returns the full square sub-matrix of \code{mu@vcov} for the requested
+#' path labels, preserving off-diagonal covariances. This is correct whether
+#' the off-diagonals are zero or non-zero.
+#'
+#' @inheritParams .resolve_path_indices
+#'
+#' @return A square numeric matrix of dimension
+#'   \code{length(path_labels)} by \code{length(path_labels)}.
+#' @keywords internal
+#' @noRd
+.extract_path_vcov <- function(mu, path_labels) {
+  idx <- .resolve_path_indices(mu, path_labels)
+  mu@vcov[idx, idx, drop = FALSE]
+}
+
+# ---- public ci methods -------------------------------------------------------
 
 #' Confidence Interval for MediationData Objects
 #'
@@ -24,7 +94,6 @@
 #'
 #' @details
 #' This method extracts the a and b path coefficients from the MediationData
-
 #' object, along with their standard errors and covariance, and computes
 #' confidence intervals using RMediation's methods.
 #'
@@ -66,180 +135,92 @@
 #' \code{\link{ProductNormal}} for the underlying distribution class
 #'
 #' @export
-ci_mediation_data <- function(mu, level = 0.95, type = "dop", n.mc = 1e5, ...) {
-  # Validate medfit is available
-
+ci_mediation_data <- function(mu, level = 0.95, type = "dop",
+                              n.mc = 1e5, ...) {
   if (!requireNamespace("medfit", quietly = TRUE)) {
-    stop("Package 'medfit' is required for this method. ",
-         "Install with: pak::pak('data-wise/medfit')",
-         call. = FALSE)
+    stop("Package 'medfit' is required for this method.", call. = FALSE)
   }
 
-  # Extract path coefficients
-  a <- mu@a_path
-  b <- mu@b_path
+  # Locate the a- and b-paths by name and build the full 2x2 covariance.
+  Sigma_2x2 <- .extract_path_vcov(mu, c("a", "b"))
 
-  # Get standard errors from estimates and vcov
-  # The estimates vector should have named elements or we need to find them
-  est_names <- names(mu@estimates)
-  vcov_mat <- mu@vcov
+  # ProductNormal's validator requires a plain square numeric matrix; strip
+  # dimnames so the named sub-matrix is accepted unconditionally.
+  dimnames(Sigma_2x2) <- NULL
 
-  # Try to find a and b in the estimates
-  # Common naming conventions: "a", "b", treatment name, mediator name
-  a_idx <- NULL
-  b_idx <- NULL
-
-  # Strategy 1: Look for "a" and "b" labels
-
-if (!is.null(est_names)) {
-    if ("a" %in% est_names) a_idx <- which(est_names == "a")
-    if ("b" %in% est_names) b_idx <- which(est_names == "b")
-  }
-
-  # Strategy 2: If vcov has row/col names, use those
-  if (is.null(a_idx) || is.null(b_idx)) {
-    vcov_names <- rownames(vcov_mat)
-    if (!is.null(vcov_names)) {
-      if ("a" %in% vcov_names) a_idx <- which(vcov_names == "a")
-      if ("b" %in% vcov_names) b_idx <- which(vcov_names == "b")
-    }
-  }
-
-  # Strategy 3: For simple mediation, a is typically position 1, b is position 2
-  # in a minimal parameter vector [a, b] or [a, b, c']
-  if (is.null(a_idx) || is.null(b_idx)) {
-    if (length(mu@estimates) >= 2) {
-      # Check if first two elements match a and b paths
-      if (abs(mu@estimates[1] - a) < 1e-10) a_idx <- 1
-      if (abs(mu@estimates[2] - b) < 1e-10) b_idx <- 2
-    }
-  }
-
-  # If we still can't find indices, compute SEs differently
-  if (is.null(a_idx) || is.null(b_idx)) {
-    # Use robust approach: extract SE from diagonal elements
-    # This is a fallback that may not capture covariance correctly
-    warning("Could not identify a and b parameters in vcov matrix. ",
-            "Using approximation assuming independent parameters.",
-            call. = FALSE)
-
-    # Estimate SEs from vcov diagonal
-    diag_var <- diag(vcov_mat)
-
-    # Find which diagonal element gives the closest match to typical SE
-    # This is a heuristic approach
-    se_a <- sqrt(diag_var[1])
-    se_b <- sqrt(diag_var[2])
-    cov_ab <- 0  # Assume independent as fallback
-  } else {
-    # Extract variances and covariance
-    se_a <- sqrt(vcov_mat[a_idx, a_idx])
-    se_b <- sqrt(vcov_mat[b_idx, b_idx])
-    cov_ab <- vcov_mat[a_idx, b_idx]
-  }
-
-  # Build covariance matrix for a, b
-  sigma_ab <- matrix(c(se_a^2, cov_ab, cov_ab, se_b^2), nrow = 2,
-                     dimnames = list(c("a", "b"), c("a", "b")))
-
-  # Create ProductNormal and compute CI
-  pn <- ProductNormal(
-    mu = c(a, b),
-    Sigma = sigma_ab
-  )
-
-  # Use the ProductNormal ci method
+  pn <- ProductNormal(mu = c(mu@a_path, mu@b_path), Sigma = Sigma_2x2)
   ci(pn, level = level, type = type, n.mc = n.mc, ...)
 }
 
 #' @rdname ci_mediation_data
 #' @export
-ci_serial_mediation_data <- function(mu, level = 0.95, type = "MC", n.mc = 1e5, ...) {
-  # Validate medfit is available
+ci_serial_mediation_data <- function(mu, level = 0.95, type = "MC",
+                                     n.mc = 1e5, ...) {
   if (!requireNamespace("medfit", quietly = TRUE)) {
-    stop("Package 'medfit' is required for this method. ",
-         "Install with: pak::pak('data-wise/medfit')",
-         call. = FALSE)
+    stop("Package 'medfit' is required for this method.", call. = FALSE)
   }
 
-  # For serial mediation (product of 3+), Monte Carlo is the practical choice
-  # since DOP doesn't generalize easily to products of 3+ normal RVs
+  checkmate::assert_count(n.mc, positive = TRUE)
+  checkmate::assert_number(level, lower = 0, upper = 1)
 
-  # Extract all path coefficients
-  a <- mu@a_path
-  d <- mu@d_path  # Vector for serial mediation
-  b <- mu@b_path
+  a_path <- mu@a_path
+  d_path <- mu@d_path
+  b_path <- mu@b_path
+  all_paths <- c(a_path, d_path, b_path)
 
-  # Total number of paths in product
-  all_paths <- c(a, d, b)
-  k <- length(all_paths)
+  # Documented label contract: the serial d-path parameters are addressed
+  # purely by NAME, using the literal labels "d1", "d2", ..., "dk" in order
+  # (k = length(mu@d_path)). There is NO positional or value-matching
+  # fallback (spec sections 3/4.1). medfit's serial extractor MUST emit
+  # named estimates/vcov whose names include "a", "b", and these "d<i>"
+  # labels (cross-reference: medfit blocker spec Open Question on d-labels).
+  # If any required label is absent, .resolve_path_indices() stops with an
+  # informative error.
+  d_labels <- .serial_d_labels(mu)
 
-  # Point estimate of indirect effect
-  indirect <- prod(all_paths)
+  Sigma <- .extract_path_vcov(mu, c("a", d_labels, "b"))
+  dimnames(Sigma) <- NULL
 
-  # For Monte Carlo, we need the full covariance matrix of [a, d1, d2, ..., b]
-  # This is complex because we need to map to the vcov matrix
-
-  # Get the vcov matrix
-  vcov_mat <- mu@vcov
-
-  # For now, use simplified approach assuming we can identify the parameters
-  # TODO: Implement full covariance extraction
-
-  # Use Monte Carlo simulation
-  # Generate samples from multivariate normal
-  if (!requireNamespace("MASS", quietly = TRUE)) {
-    stop("Package 'MASS' is required for Monte Carlo CI",
-         call. = FALSE)
-  }
-
-  # Try to extract sub-covariance matrix for the paths
-  # This is a placeholder - full implementation would need parameter mapping
-  n_params <- length(mu@estimates)
-
-  if (n_params == k) {
-    # Simple case: estimates are just the path coefficients
-    sigma_paths <- vcov_mat
-  } else {
-    # Complex case: need to extract relevant sub-matrix
-    # For now, use diagonal (assuming independence) with warning
-    warning("Full covariance extraction for serial mediation not yet implemented. ",
-            "Using diagonal variance approximation.",
-            call. = FALSE)
-    sigma_paths <- diag(diag(vcov_mat)[seq_len(k)])
-  }
-
-  # Monte Carlo simulation
-  samples <- MASS::mvrnorm(n = n.mc, mu = all_paths, Sigma = sigma_paths)
-
-  # Compute product for each sample (product across columns)
-  indirect_samples <- apply(samples, 1, prod)
-
-  # Compute CI from quantiles
+  # Defensive guard against a mean/covariance order mismatch: the mean vector
+  # passed to mvrnorm must align row-for-row with Sigma.
+  stopifnot(length(all_paths) == nrow(Sigma))
+  draws <- MASS::mvrnorm(n = n.mc, mu = all_paths, Sigma = Sigma)
+  products <- apply(draws, 1, prod)
   alpha <- 1 - level
-  ci_lower <- stats::quantile(indirect_samples, alpha / 2)
-  ci_upper <- stats::quantile(indirect_samples, 1 - alpha / 2)
+  ci_bounds <- stats::quantile(products, probs = c(alpha / 2, 1 - alpha / 2))
 
-  # Standard error from samples
-  se_indirect <- stats::sd(indirect_samples)
-
+  # Backward-compatible return shape (spec section 4.4): preserve the names
+  # and components of the original ci_serial_mediation_data() output.
   list(
-    CI = c(lower = unname(ci_lower), upper = unname(ci_upper)),
-    Estimate = indirect,
-    SE = se_indirect,
+    CI = c(lower = unname(ci_bounds[1]), upper = unname(ci_bounds[2])),
+    Estimate = prod(all_paths),
+    SE = stats::sd(products),
     type = "MC (serial mediation)",
     level = level,
     n.mc = n.mc,
-    k = k  # Number of paths in product
+    k = length(d_path)
   )
 }
 
+#' Derive the d-path labels for a serial mediation object
+#'
+#' Returns the literal, NAME-ONLY label contract for the serial d-paths:
+#' \code{paste0("d", seq_along(mu@d_path))} (i.e. "d1", "d2", ...). These are
+#' resolved purely by name downstream via \code{.resolve_path_indices()}; there
+#' is no positional or value-matching fallback (spec sections 3/4.1). medfit's
+#' serial extractor must emit estimates/vcov carrying these names.
+#'
+#' @inheritParams .resolve_path_indices
+#' @return Character vector of d-path labels of length \code{length(mu@d_path)}.
+#' @keywords internal
+#' @noRd
+.serial_d_labels <- function(mu) {
+  paste0("d", seq_along(mu@d_path))
+}
 
-# Dynamic method registration in .onLoad
-# This will be called from zzz.R
+# Dynamic method registration in .onLoad (called from zzz.R)
 .register_medfit_methods <- function() {
   if (requireNamespace("medfit", quietly = TRUE)) {
-    # Get the MediationData and SerialMediationData classes from medfit
     tryCatch({
       # Register ci method for MediationData
       MediationData_class <- medfit::MediationData
@@ -249,8 +230,13 @@ ci_serial_mediation_data <- function(mu, level = 0.95, type = "MC", n.mc = 1e5, 
       SerialMediationData_class <- medfit::SerialMediationData
       S7::method(ci, SerialMediationData_class) <- ci_serial_mediation_data
     }, error = function(e) {
-      # Silently fail if registration doesn't work
-      # Methods will still be available as regular functions
+      # Make registration failure visible (but non-fatal): the functions remain
+      # available as regular exported functions, but a broken S7 registration
+      # should be diagnosable rather than silently swallowed.
+      packageStartupMessage(
+        "RMediation: failed to register medfit S7 ci methods: ",
+        conditionMessage(e)
+      )
     })
   }
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![R-CMD-check](https://github.com/data-wise/rmediation/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/data-wise/rmediation/actions/workflows/R-CMD-check.yaml)
 [![Website](https://github.com/data-wise/rmediation/actions/workflows/pkgdown.yaml/badge.svg)](https://data-wise.github.io/rmediation/)
 [![R-hub](https://github.com/data-wise/rmediation/actions/workflows/rhub.yaml/badge.svg)](https://github.com/data-wise/rmediation/actions/workflows/rhub.yaml)
-[![Codecov](https://codecov.io/gh/data-wise/rmediation/graph/badge.svg)](https://codecov.io/gh/data-wise/rmediation)
+[![Codecov](https://codecov.io/gh/data-wise/rmediation/graph/badge.svg)](https://app.codecov.io/gh/data-wise/rmediation)
 <!-- badges: end -->
 
 ## Overview
@@ -166,7 +166,7 @@ mbco(model, effect = "ab", n.boot = 1000, type = "parametric")
 | [**medfit**](https://data-wise.github.io/medfit/) | Model fitting and coefficient extraction |
 | [**probmed**](https://data-wise.github.io/probmed/) | Probabilistic effect size (P_med) |
 | **RMediation** | Confidence intervals (DOP, Monte Carlo, MBCO) |
-| [**medrobust**](https://data-wise.github.io/medrobust/) | Sensitivity analysis |
+| [**medrobust**](https://github.com/data-wise/medrobust) | Sensitivity analysis | [github](https://github.com/data-wise/medrobust) |
 | [**medsim**](https://data-wise.github.io/medsim/) | Simulation infrastructure |
 
 Install the entire ecosystem:

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ install.packages("RMediation")
 
 ```r
 # Using pak (recommended)
-pak::pak("Data-Wise/rmediation@develop")
+pak::pak("Data-Wise/rmediation@dev")
 
 # Or using remotes
-remotes::install_github("Data-Wise/rmediation", ref = "develop")
+remotes::install_github("Data-Wise/rmediation", ref = "dev")
 ```
 
 ## Usage

--- a/tests/testthat/test-ci-medfit-covariance.R
+++ b/tests/testthat/test-ci-medfit-covariance.R
@@ -1,0 +1,290 @@
+#' Tests for name-based covariance extraction from medfit objects
+#'
+#' These tests cover the path -> covariance resolver used by
+#' \code{ci_mediation_data()} and \code{ci_serial_mediation_data()}.
+
+skip_if_not_installed("medfit")
+
+# ---- fixtures ---------------------------------------------------------------
+
+make_md <- function(cov_ab = 0) {
+  vcov_mat <- matrix(
+    c(0.01,  cov_ab, 0,
+      cov_ab, 0.02,  0,
+      0,      0,     0.015),
+    nrow = 3, ncol = 3,
+    dimnames = list(c("a", "b", "c_prime"),
+                    c("a", "b", "c_prime"))
+  )
+  medfit::MediationData(
+    a_path = 0.5, b_path = 0.4, c_prime = 0.1,
+    estimates = c(a = 0.5, b = 0.4, c_prime = 0.1),
+    vcov = vcov_mat,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = character(0), outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+}
+
+make_serial <- function(off_diag = 0) {
+  # 2 mediators -> d_path length 1. Paths order: a, d1, b.
+  od <- off_diag
+  vcov_mat <- matrix(
+    c(0.01, od,   od,
+      od,   0.02, od,
+      od,   od,   0.015),
+    nrow = 3, ncol = 3,
+    dimnames = list(c("a", "d1", "b"),
+                    c("a", "d1", "b"))
+  )
+  medfit::SerialMediationData(
+    a_path = 0.5, d_path = 0.3, b_path = 0.4, c_prime = 0.1,
+    estimates = c(a = 0.5, d1 = 0.3, b = 0.4),
+    vcov = vcov_mat,
+    sigma_mediators = NULL, sigma_y = NULL,
+    treatment = "X", mediators = c("M1", "M2"), outcome = "Y",
+    mediator_predictors = list("X", c("X", "M1")),
+    outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+}
+
+# ---- 1. covariance present is extracted by name -----------------------------
+
+test_that(".extract_path_vcov reads the true off-diagonal cov(a, b)", {
+  md <- make_md(cov_ab = 0.003)
+  Sigma <- RMediation:::.extract_path_vcov(md, c("a", "b"))
+  expect_equal(dim(Sigma), c(2L, 2L))
+  expect_equal(Sigma["a", "b"], 0.003)
+  expect_equal(Sigma["a", "a"], 0.01)
+  expect_equal(Sigma["b", "b"], 0.02)
+})
+
+# ---- 2. cross-method agreement (dop vs MC vs medci) -------------------------
+
+test_that("ci() dop and MC agree with each other and with medci", {
+  cov_ab <- 0.003
+  md <- make_md(cov_ab = cov_ab)
+
+  res_dop <- RMediation::ci(md, type = "dop")
+  set.seed(42)
+  res_mc <- RMediation::ci(md, type = "MC", n.mc = 2e5)
+
+  # dop and MC agree within ~2% on each CI bound
+  expect_equal(as.numeric(res_dop$CI), as.numeric(res_mc$CI),
+               tolerance = 0.02)
+
+  # both agree with a direct medci() call carrying the same correlation.
+  # medci(type = "dop") returns a list whose first element is the CI vector
+  # (named "<level>% CI"), so reference it positionally.
+  se_a <- sqrt(0.01)
+  se_b <- sqrt(0.02)
+  rho <- cov_ab / (se_a * se_b)
+  ref <- RMediation::medci(mu.x = 0.5, mu.y = 0.4, se.x = se_a, se.y = se_b,
+                           rho = rho, alpha = 0.05, type = "dop")
+  expect_equal(as.numeric(res_dop$CI), as.numeric(ref[[1]]),
+               tolerance = 1e-6)
+})
+
+# ---- 3. serial uses the FULL covariance, not a diagonal approximation -------
+
+test_that("serial ci uses full covariance matching a reference simulation", {
+  off_diag <- 0.004
+  smd <- make_serial(off_diag = off_diag)
+  all_paths <- c(0.5, 0.3, 0.4)
+
+  Sigma_full <- matrix(
+    c(0.01, off_diag, off_diag,
+      off_diag, 0.02, off_diag,
+      off_diag, off_diag, 0.015),
+    nrow = 3, ncol = 3
+  )
+  Sigma_diag <- diag(diag(Sigma_full))
+
+  set.seed(7)
+  res <- RMediation::ci(smd, type = "MC", n.mc = 1e5)
+
+  # The CI must DIFFER from a diagonal-only approximation: this proves the
+  # off-diagonal covariances are actually used (not silently dropped).
+  set.seed(7)
+  draws_diag <- MASS::mvrnorm(n = 1e5, mu = all_paths, Sigma = Sigma_diag)
+  prod_diag <- apply(draws_diag, 1, prod)
+  ci_diag <- unname(stats::quantile(prod_diag, probs = c(0.025, 0.975)))
+
+  expect_false(isTRUE(all.equal(unname(res$CI), ci_diag, tolerance = 1e-6)))
+
+  # Non-tautological accuracy check: compare against an INDEPENDENT large-n
+  # Monte Carlo reference using a DIFFERENT seed and the FULL Sigma. Reusing
+  # the same seed for both legs would make this a tautology; a different seed
+  # with a loose tolerance absorbs MC noise while still catching a wrong Sigma.
+  set.seed(20240601)
+  ref_draws <- MASS::mvrnorm(n = 2e5, mu = all_paths, Sigma = Sigma_full)
+  ref_product <- apply(ref_draws, 1, prod)
+  ref_ci <- unname(stats::quantile(ref_product, probs = c(0.025, 0.975)))
+  expect_equal(unname(res$CI), ref_ci, tolerance = 0.03)
+})
+
+# ---- 3b. serial preserves the backward-compatible return shape --------------
+
+test_that("ci_serial_mediation_data preserves the original return shape", {
+  smd <- make_serial(off_diag = 0.004)
+
+  set.seed(11)
+  res <- RMediation::ci(smd, type = "MC", n.mc = 2000)
+
+  # Original shape (spec 4.4): CI (named lower/upper), Estimate, SE, type,
+  # level, n.mc, k.
+  expect_named(res, c("CI", "Estimate", "SE", "type", "level", "n.mc", "k"))
+  expect_named(res$CI, c("lower", "upper"))
+  expect_lt(res$CI[["lower"]], res$CI[["upper"]])
+  expect_equal(res$Estimate, 0.5 * 0.3 * 0.4)
+  expect_gt(res$SE, 0)
+  expect_equal(res$type, "MC (serial mediation)")
+  expect_equal(res$level, 0.95)
+  expect_equal(res$n.mc, 2000)
+  # d_path has length 1 in this 2-mediator fixture.
+  expect_identical(res$k, 1L)
+})
+
+# ---- 4. error path: unnamed vcov/estimates cannot be resolved ---------------
+
+test_that("unresolvable labels raise an informative error (no silent independence)", {
+  vcov_mat <- matrix(
+    c(0.01, 0.003, 0,
+      0.003, 0.02, 0,
+      0, 0, 0.015),
+    nrow = 3, ncol = 3
+  )  # no dimnames
+  md <- medfit::MediationData(
+    a_path = 0.5, b_path = 0.4, c_prime = 0.1,
+    estimates = c(0.5, 0.4, 0.1),  # no names
+    vcov = vcov_mat,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = character(0), outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+  # The error must be the SPECIFIC informative message about being unable to
+  # resolve parameters by name -- not any incidental crash. This matches the
+  # resolver's wording for the "no dimnames and unnamed estimates" branch.
+  expect_error(
+    RMediation::ci(md, type = "dop"),
+    regexp = "Cannot resolve path parameters by name"
+  )
+  expect_error(
+    RMediation:::.resolve_path_indices(md, c("a", "b")),
+    regexp = "Cannot resolve path parameters by name"
+  )
+})
+
+test_that("missing path labels raise the specific 'Could not resolve' error", {
+  # Names exist but do not include the requested a/b labels.
+  vcov_mat <- matrix(
+    c(0.01, 0, 0, 0.02), nrow = 2,
+    dimnames = list(c("x", "y"), c("x", "y"))
+  )
+  md <- medfit::MediationData(
+    a_path = 0.5, b_path = 0.4, c_prime = 0.1,
+    estimates = c(x = 0.5, y = 0.4),
+    vcov = vcov_mat,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = character(0), outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+  expect_error(
+    RMediation:::.resolve_path_indices(md, c("a", "b")),
+    regexp = "Could not resolve path label\\(s\\): a, b"
+  )
+})
+
+# ---- 5. non-zero cov(a, b) changes the CI -----------------------------------
+
+test_that("non-zero cov(a, b) yields a different CI than independence", {
+  md0 <- make_md(cov_ab = 0)
+  md1 <- make_md(cov_ab = 0.006)
+
+  ci0 <- RMediation::ci(md0, type = "dop")$CI
+  ci1 <- RMediation::ci(md1, type = "dop")$CI
+
+  expect_false(isTRUE(all.equal(ci0, ci1, tolerance = 1e-6)))
+})
+
+# ---- 6. name-based slicing: block-diagonal lm case (a/b non-adjacent) -------
+
+test_that(".extract_path_vcov uses NAME-based slicing (block-diagonal, lm case)", {
+  # Block-diagonal vcov with cov(a, b) = 0, and a NUISANCE parameter placed
+  # BETWEEN a and b so that a/b sit at non-adjacent positions (1 and 3). A
+  # positional 1:2 slice would pick up the nuisance row/col; name resolution
+  # must extract exactly the a/b sub-block.
+  vcov_mat <- matrix(
+    c(0.04, 0.00, 0.00,
+      0.00, 0.50, 0.00,
+      0.00, 0.00, 0.09),
+    nrow = 3, ncol = 3, byrow = TRUE,
+    dimnames = list(c("a", "nuisance", "b"),
+                    c("a", "nuisance", "b"))
+  )
+  md <- medfit::MediationData(
+    a_path = 0.4, b_path = 0.6, c_prime = 0.1,
+    estimates = c(a = 0.4, nuisance = 1.23, b = 0.6),
+    vcov = vcov_mat,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = character(0), outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+
+  # Indices must come from NAMES (1 and 3), not positions 1 and 2.
+  idx <- RMediation:::.resolve_path_indices(md, c("a", "b"))
+  expect_equal(idx, c(1L, 3L))
+
+  Sigma <- RMediation:::.extract_path_vcov(md, c("a", "b"))
+  expect_equal(dim(Sigma), c(2L, 2L))
+  # cov(a, b) == 0 (block-diagonal lm case)
+  expect_equal(Sigma["a", "b"], 0)
+  expect_equal(Sigma["b", "a"], 0)
+  # Diagonal entries are the a/b variances, NOT the nuisance variance (0.50).
+  expect_equal(Sigma["a", "a"], 0.04)
+  expect_equal(Sigma["b", "b"], 0.09)
+  expect_false(any(Sigma == 0.50))
+})
+
+# ---- 7. covariates / interspersed a and b columns ---------------------------
+
+test_that(".extract_path_vcov matches the named sub-matrix when a/b are interspersed", {
+  # a and b are NOT in positions 1, 2: extra coefficients surround them and
+  # cov(a, b) is non-zero. The extracted Sigma must equal the correctly-NAMED
+  # a/b sub-matrix, not a positional slice.
+  nm <- c("intercept", "a", "covariate", "b", "cp")
+  full <- matrix(0, nrow = 5, ncol = 5, dimnames = list(nm, nm))
+  diag(full) <- c(0.10, 0.04, 0.20, 0.09, 0.01)
+  full["a", "b"] <- 0.015
+  full["b", "a"] <- 0.015
+
+  md <- medfit::MediationData(
+    a_path = 0.4, b_path = 0.6, c_prime = 0.2,
+    estimates = c(intercept = 1, a = 0.4, covariate = 0.3, b = 0.6, cp = 0.2),
+    vcov = full,
+    sigma_m = NULL, sigma_y = NULL,
+    treatment = "X", mediator = "M", outcome = "Y",
+    mediator_predictors = "covariate", outcome_predictors = "covariate",
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+
+  idx <- RMediation:::.resolve_path_indices(md, c("a", "b"))
+  expect_equal(idx, c(2L, 4L)) # name-based positions, not 1:2
+
+  Sigma <- RMediation:::.extract_path_vcov(md, c("a", "b"))
+  expected <- full[c("a", "b"), c("a", "b")]
+  expect_equal(Sigma, expected)
+  expect_equal(Sigma["a", "b"], 0.015)
+})
+
+# ---- 8. serial d-label contract is the literal d1..dk ----------------------
+
+test_that(".serial_d_labels returns the literal d1..dk name contract", {
+  smd <- make_serial(off_diag = 0)  # d_path length 1 -> "d1"
+  expect_equal(RMediation:::.serial_d_labels(smd), "d1")
+})

--- a/tests/testthat/test-ci-medfit-covariance.R
+++ b/tests/testthat/test-ci-medfit-covariance.R
@@ -301,7 +301,9 @@ test_that("ci() type = 'asymp' returns a valid interval via the resolver", {
   expect_length(as.numeric(res$CI), 2L)
   expect_true(all(is.finite(as.numeric(res$CI))))
   expect_lt(as.numeric(res$CI)[1], as.numeric(res$CI)[2])
-  expect_equal(res$Estimate, 0.5 * 0.4)   # a*b point estimate
+  # The delta/asymptotic point estimate of E[ab] is bias-corrected:
+  # E[ab] = a*b + cov(a, b) = 0.2 + 0.003. (Not the naive product a*b.)
+  expect_equal(res$Estimate, 0.5 * 0.4 + 0.003)
   expect_gt(res$SE, 0)
 })
 

--- a/tests/testthat/test-ci-medfit-covariance.R
+++ b/tests/testthat/test-ci-medfit-covariance.R
@@ -288,3 +288,84 @@ test_that(".serial_d_labels returns the literal d1..dk name contract", {
   smd <- make_serial(off_diag = 0)  # d_path length 1 -> "d1"
   expect_equal(RMediation:::.serial_d_labels(smd), "d1")
 })
+
+# ---- 9. asymp (delta) method also routes through name-based extraction ------
+
+test_that("ci() type = 'asymp' returns a valid interval via the resolver", {
+  # The asymp/delta path is documented but was previously untested. It must
+  # produce a finite CI/Estimate/SE built from the name-resolved 2x2 Sigma.
+  md <- make_md(cov_ab = 0.003)
+  res <- RMediation::ci(md, type = "asymp")
+
+  expect_true(all(c("CI", "Estimate", "SE") %in% names(res)))
+  expect_length(as.numeric(res$CI), 2L)
+  expect_true(all(is.finite(as.numeric(res$CI))))
+  expect_lt(as.numeric(res$CI)[1], as.numeric(res$CI)[2])
+  expect_equal(res$Estimate, 0.5 * 0.4)   # a*b point estimate
+  expect_gt(res$SE, 0)
+})
+
+# ---- 10. serial input validation (n.mc, level) -----------------------------
+
+test_that("ci_serial_mediation_data validates n.mc and level", {
+  smd <- make_serial(off_diag = 0)
+
+  # n.mc must be a positive count.
+  expect_error(
+    RMediation::ci(smd, type = "MC", n.mc = -5),
+    regexp = "n.mc"
+  )
+  expect_error(
+    RMediation::ci(smd, type = "MC", n.mc = 0),
+    regexp = "n.mc"
+  )
+  # level must be in [0, 1].
+  expect_error(
+    RMediation::ci(smd, type = "MC", level = 1.5),
+    regexp = "level"
+  )
+})
+
+# ---- 11. three-mediator serial chain (d_path length 2 -> d1, d2) ------------
+
+test_that("serial ci handles a 3-mediator chain (d1, d2) with full covariance", {
+  # d_path length 2 exercises the multi-d label contract c("a", "d1", "d2", "b")
+  # and a 4x4 covariance sub-matrix -- the 2-mediator fixture only covers d1.
+  nm <- c("a", "d1", "d2", "b")
+  od <- 0.003
+  vcov_mat <- matrix(od, nrow = 4, ncol = 4, dimnames = list(nm, nm))
+  diag(vcov_mat) <- c(0.01, 0.02, 0.03, 0.04)
+
+  smd3 <- medfit::SerialMediationData(
+    a_path = 0.5, d_path = c(0.3, 0.35), b_path = 0.4, c_prime = 0.1,
+    estimates = c(a = 0.5, d1 = 0.3, d2 = 0.35, b = 0.4),
+    vcov = vcov_mat,
+    sigma_mediators = NULL, sigma_y = NULL,
+    treatment = "X", mediators = c("M1", "M2", "M3"), outcome = "Y",
+    mediator_predictors = list("X", c("X", "M1"), c("X", "M1", "M2")),
+    outcome_predictors = character(0),
+    data = NULL, n_obs = 200L, converged = TRUE, source_package = "manual"
+  )
+
+  # Labels and resolved indices span all four chain parameters.
+  expect_equal(RMediation:::.serial_d_labels(smd3), c("d1", "d2"))
+  expect_equal(
+    RMediation:::.resolve_path_indices(smd3, c("a", "d1", "d2", "b")),
+    1:4
+  )
+
+  set.seed(99)
+  res <- RMediation::ci(smd3, type = "MC", n.mc = 5e4)
+  expect_identical(res$k, 2L)
+  expect_equal(res$Estimate, 0.5 * 0.3 * 0.35 * 0.4)
+  expect_lt(res$CI[["lower"]], res$CI[["upper"]])
+
+  # Result must reflect the full (non-diagonal) Sigma: compare to a same-seed
+  # diagonal-only draw and require it to differ.
+  set.seed(99)
+  diag_draws <- MASS::mvrnorm(n = 5e4, mu = c(0.5, 0.3, 0.35, 0.4),
+                              Sigma = diag(diag(vcov_mat)))
+  diag_ci <- unname(stats::quantile(apply(diag_draws, 1, prod),
+                                    probs = c(0.025, 0.975)))
+  expect_false(isTRUE(all.equal(unname(res$CI), diag_ci, tolerance = 1e-6)))
+})

--- a/tests/testthat/test-serial-medfit-integration.R
+++ b/tests/testthat/test-serial-medfit-integration.R
@@ -1,0 +1,55 @@
+#' Integration test: end-to-end serial mediation via the REAL medfit extractor
+#'
+#' Unlike test-ci-medfit-covariance.R (which builds SerialMediationData by hand),
+#' this fits an actual lavaan model, runs medfit::extract_mediation() to produce
+#' a SerialMediationData, and feeds it to ci(). This exercises the full wiring:
+#' fit -> medfit serial extractor (@vcov named a, d1.., b, c_prime) -> rmediation
+#' .serial_d_labels resolver -> ci_serial_mediation_data().
+#'
+#' Requires medfit >= 0.2.0 — the first release shipping the serial extractor.
+
+skip_if_not_installed("medfit")
+skip_if_not_installed("lavaan")
+skip_if(
+  utils::packageVersion("medfit") < "0.2.0",
+  "serial mediation extractor requires medfit >= 0.2.0"
+)
+
+test_that("lavaan 2-mediator chain: extract_mediation() -> ci() recovers the indirect effect", {
+  set.seed(42)
+  n <- 800
+  X  <- rnorm(n)
+  M1 <- 0.5 * X  + rnorm(n)
+  M2 <- 0.6 * M1 + rnorm(n)
+  Y  <- 0.7 * M2 + 0.2 * X + rnorm(n)
+  dat <- data.frame(X, M1, M2, Y)
+
+  model <- "M1 ~ a*X
+            M2 ~ d1*M1
+            Y  ~ b*M2 + cp*X"
+  fit <- lavaan::sem(model, data = dat)
+
+  mu <- medfit::extract_mediation(
+    fit, treatment = "X", mediator = c("M1", "M2"), outcome = "Y"
+  )
+
+  # medfit emits the name contract rmediation's resolver depends on
+  expect_true(all(c("a", "d1", "b", "c_prime") %in% names(mu@estimates)))
+  expect_true(all(c("a", "d1", "b") %in% rownames(mu@vcov)))
+  expect_length(mu@d_path, 1L) # k - 1 for 2 mediators
+
+  res <- ci(mu, level = 0.95, type = "MC")
+
+  # Return shape
+  expect_type(res, "list")
+  expect_true(all(c("CI", "Estimate", "SE", "type", "k") %in% names(res)))
+  expect_identical(res$k, 1L)
+
+  # Point estimate near the true serial indirect effect a*d1*b = 0.5*0.6*0.7 = 0.21
+  expect_equal(unname(res$Estimate), 0.21, tolerance = 0.04)
+
+  # The 95% CI brackets the truth and is a proper interval
+  expect_lt(res$CI[["lower"]], 0.21)
+  expect_gt(res$CI[["upper"]], 0.21)
+  expect_lt(res$CI[["lower"]], res$CI[["upper"]])
+})

--- a/tests/testthat/test-serial-medfit-integration.R
+++ b/tests/testthat/test-serial-medfit-integration.R
@@ -45,10 +45,51 @@ test_that("lavaan 2-mediator chain: extract_mediation() -> ci() recovers the ind
   expect_true(all(c("CI", "Estimate", "SE", "type", "k") %in% names(res)))
   expect_identical(res$k, 1L)
 
-  # Point estimate near the true serial indirect effect a*d1*b = 0.5*0.6*0.7 = 0.21
-  expect_equal(unname(res$Estimate), 0.21, tolerance = 0.04)
+  # Point estimate is a sensible serial indirect effect (true a*d1*b = 0.21).
+  # Range check, not expect_equal (testthat tolerance is RELATIVE) — the wiring
+  # check that matters is the CI bracketing the truth below.
+  expect_gt(unname(res$Estimate), 0.12)
+  expect_lt(unname(res$Estimate), 0.30)
 
   # The 95% CI brackets the truth and is a proper interval
+  expect_lt(res$CI[["lower"]], 0.21)
+  expect_gt(res$CI[["upper"]], 0.21)
+  expect_lt(res$CI[["lower"]], res$CI[["upper"]])
+})
+
+test_that("lm/glm 2-mediator chain: extract_mediation(mediator_models=) -> ci() works", {
+  # Exercises the lm/sequential-regression serial path (medfit's `mediator_models`
+  # argument) — the half of decision #2 that was the original lm gap. lm chains are
+  # block-structured (separate equations), distinct from the lavaan single-equation case.
+  set.seed(7)
+  n <- 800
+  X  <- rnorm(n)
+  M1 <- 0.5 * X  + rnorm(n)
+  M2 <- 0.6 * M1 + rnorm(n)
+  Y  <- 0.7 * M2 + 0.2 * X + rnorm(n)
+  dat <- data.frame(X, M1, M2, Y)
+
+  fit_m1 <- lm(M1 ~ X, data = dat)      # first mediator model
+  fit_m2 <- lm(M2 ~ M1, data = dat)     # mediators 2..k
+  fit_y  <- lm(Y ~ M2 + X, data = dat)  # outcome model
+
+  mu <- medfit::extract_mediation(
+    fit_m1, model_y = fit_y, treatment = "X",
+    mediator = c("M1", "M2"), mediator_models = list(fit_m2)
+  )
+
+  expect_true(all(c("a", "d1", "b", "c_prime") %in% names(mu@estimates)))
+  expect_true(all(c("a", "d1", "b") %in% rownames(mu@vcov)))
+  expect_length(mu@d_path, 1L)
+
+  res <- ci(mu, level = 0.95, type = "MC")
+
+  expect_type(res, "list")
+  expect_true(all(c("CI", "Estimate", "SE") %in% names(res)))
+  # Sensible serial indirect effect (true a*d1*b = 0.21); generous band, lm point
+  # estimates vary more than the single-equation SEM fit.
+  expect_gt(unname(res$Estimate), 0.12)
+  expect_lt(unname(res$Estimate), 0.33)
   expect_lt(res$CI[["lower"]], 0.21)
   expect_gt(res$CI[["upper"]], 0.21)
   expect_lt(res$CI[["lower"]], res$CI[["upper"]])


### PR DESCRIPTION
## Summary

- medfit 0.2.1 is now on CRAN; drop `Remotes: data-wise/medfit` so CRAN resolves it from its own servers
- Pin `Suggests: medfit (>= 0.2.0)` (floor matches the first CRAN release)
- `requireNamespace()` guards in `ci_medfit.R` unchanged — medfit remains in `Suggests`
- Bump version 1.4.0 → **1.5.0**

## R CMD check

`Remotes:` NOTE is gone. Pre-existing vignette warnings (no pre-built `inst/doc`) are unrelated to this change and expected in local `--no-build-vignettes` builds; CI builds full vignettes.

## Test plan

- [ ] CI green (R-CMD-check all platforms)
- [ ] `ci()` for `MediationData` / `SerialMediationData` still passes (uses CRAN medfit)
- [ ] Merge to main → tag v1.5.0 → GitHub release → submit to CRAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)